### PR TITLE
fix: adjust quantity of edgeband inventory to be an int not a double

### DIFF
--- a/Applications/MaterialManager/Contracts/Material/Edgebands/EdgebandTypeInventory.cs
+++ b/Applications/MaterialManager/Contracts/Material/Edgebands/EdgebandTypeInventory.cs
@@ -45,7 +45,7 @@ namespace HomagConnect.MaterialManager.Contracts.Material.Edgebands
         /// <summary>
         /// Gets or sets the quantity.
         /// </summary>
-        public double? Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or sets the additional comments of the instance data.


### PR DESCRIPTION
… of the `Quantity` property in the `EdgebandTypeInventory.cs` file. It was previously a nullable `double` type and has now been changed to a nullable `int` type.

List of Changes:
1. The `Quantity` property's data type in the `EdgebandTypeInventory.cs` file under the `HomagConnect.MaterialManager.Contracts.Material.Edgebands` namespace has been changed from a nullable `double` (`double?`) to a nullable `int` (`int?`).

Reference to the Code Changes:
- The change in the data type of the `Quantity` property in the `EdgebandTypeInventory.cs` file can be found in the `HomagConnect.MaterialManager.Contracts.Material.Edgebands` namespace.