### PR TITLE
Add the EdgebandUsage model to the intelliDivide client

### DIFF
--- a/Applications/IntelliDivide/Contracts/Statistics/EdebandUsage.cs
+++ b/Applications/IntelliDivide/Contracts/Statistics/EdebandUsage.cs
@@ -1,0 +1,84 @@
+﻿using HomagConnect.Base.Contracts.Enumerations;
+using HomagConnect.Base.Contracts.Interfaces;
+using Newtonsoft.Json;
+using System;
+using System.Runtime.Serialization;
+
+namespace HomagConnect.IntelliDivide.Contracts.Statistics
+{
+    public class EdebandUsage : IExtensibleDataObject, IContainsUnitSystemDependentProperties
+    {
+        /// <summary>
+        /// The time when the optimization job was downloaded or transferred to productionAssist
+        /// </summary>
+        [JsonProperty(Order = 1)]
+        public DateTimeOffset TransferredAt { get; set; }
+
+
+        /// <summary>
+        /// The unique GUID of the optimization job id
+        /// </summary>
+        [JsonProperty(Order = 2)]
+        public Guid OptimizationId { get; set; }
+
+        /// <summary>
+        /// The optimization job name from which we computed the edgebands
+        /// </summary>
+        [JsonProperty(Order = 3)]
+        public string OptimizationName { get; set; }
+
+
+        /// <summary>
+        /// the edgeband code assigned to this edgeband
+        /// </summary>
+        [JsonProperty(Order = 4)]
+        public string EdgebandCode { get; set; }
+
+        /// <summary>
+        /// The unit system measure, default is metric
+        /// </summary>
+        [JsonProperty(Order = 5)]
+        public UnitSystem UnitSystem { get; set; } = UnitSystem.Metric;
+
+        /// <summary>
+        /// Total length used for edgebands of this type
+        /// </summary>
+        [JsonProperty(Order = 6)]
+        public double? LengthUsed { get; set; }
+
+        /// <summary>
+        /// Cost of edgebands per unit (meters or feet)
+        /// </summary>
+        [JsonProperty(Order = 7)]
+        public double? Costs { get; set; }
+
+
+        #region Calculated Value
+
+        /// <summary>
+        /// Gets the total value of edgebands of this type 
+        /// </summary>
+        [JsonProperty(Order = 8)]
+        public double? TotalCosts
+        {
+            get
+            {
+                if (LengthUsed.HasValue && Costs.HasValue)
+                {
+                    return Costs.Value * LengthUsed.Value;
+                }
+
+                return null;
+            }
+        }
+
+        #endregion
+
+        #region IExtensibleDataObject Members
+
+        /// <inheritdoc />
+        public ExtensionDataObject? ExtensionData { get; set; }
+
+        #endregion
+    }
+}

--- a/Applications/IntelliDivide/Contracts/Statistics/EdebandUsage.cs
+++ b/Applications/IntelliDivide/Contracts/Statistics/EdebandUsage.cs
@@ -1,19 +1,24 @@
-﻿using HomagConnect.Base.Contracts.Enumerations;
-using HomagConnect.Base.Contracts.Interfaces;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Runtime.Serialization;
+
+using HomagConnect.Base.Contracts.Attributes;
+using HomagConnect.Base.Contracts.Enumerations;
+using HomagConnect.Base.Contracts.Interfaces;
+
+using Newtonsoft.Json;
 
 namespace HomagConnect.IntelliDivide.Contracts.Statistics
 {
-    public class EdebandUsage : IExtensibleDataObject, IContainsUnitSystemDependentProperties
+    /// <summary>
+    /// Provides the edgeband usage data for an optimization.
+    /// </summary>
+    public class EdgebandUsage : IExtensibleDataObject, IContainsUnitSystemDependentProperties
     {
         /// <summary>
-        /// The time when the optimization job was downloaded or transferred to productionAssist
+        /// The time when the optimization job was downloaded or transferred
         /// </summary>
         [JsonProperty(Order = 1)]
         public DateTimeOffset TransferredAt { get; set; }
-
 
         /// <summary>
         /// The unique GUID of the optimization job id
@@ -22,11 +27,10 @@ namespace HomagConnect.IntelliDivide.Contracts.Statistics
         public Guid OptimizationId { get; set; }
 
         /// <summary>
-        /// The optimization job name from which we computed the edgebands
+        /// The optimization name from which we computed the edgebands
         /// </summary>
         [JsonProperty(Order = 3)]
         public string OptimizationName { get; set; }
-
 
         /// <summary>
         /// the edgeband code assigned to this edgeband
@@ -35,15 +39,10 @@ namespace HomagConnect.IntelliDivide.Contracts.Statistics
         public string EdgebandCode { get; set; }
 
         /// <summary>
-        /// The unit system measure, default is metric
-        /// </summary>
-        [JsonProperty(Order = 5)]
-        public UnitSystem UnitSystem { get; set; } = UnitSystem.Metric;
-
-        /// <summary>
-        /// Total length used for edgebands of this type
+        /// Total length used for edgebands of this type (meters or feet)
         /// </summary>
         [JsonProperty(Order = 6)]
+        [ValueDependsOnUnitSystem(BaseUnit.Meter)]
         public double? LengthUsed { get; set; }
 
         /// <summary>
@@ -52,11 +51,8 @@ namespace HomagConnect.IntelliDivide.Contracts.Statistics
         [JsonProperty(Order = 7)]
         public double? Costs { get; set; }
 
-
-        #region Calculated Value
-
         /// <summary>
-        /// Gets the total value of edgebands of this type 
+        /// Gets the total value of edgebands of this type
         /// </summary>
         [JsonProperty(Order = 8)]
         public double? TotalCosts
@@ -72,11 +68,18 @@ namespace HomagConnect.IntelliDivide.Contracts.Statistics
             }
         }
 
+        #region IContainsUnitSystemDependentProperties Members
+
+        /// <inheritdoc />
+        [JsonProperty(Order = 99)]
+        public UnitSystem UnitSystem { get; set; } = UnitSystem.Metric;
+
         #endregion
 
         #region IExtensibleDataObject Members
 
         /// <inheritdoc />
+        [JsonProperty(Order = 99)]
         public ExtensionDataObject? ExtensionData { get; set; }
 
         #endregion


### PR DESCRIPTION
Extend the IntelliDivide Contracts to contain the EdgebandUsage model. This represents the aggregations for each optimization job of the edgeband length used. The cost of the material and the total cost of the edgebands used is also provided.