### PR TITLE
feat: add external id to material types

### DIFF
--- a/Applications/MaterialManager/Contracts/Material/Boards/BoardType.cs
+++ b/Applications/MaterialManager/Contracts/Material/Boards/BoardType.cs
@@ -172,6 +172,12 @@ namespace HomagConnect.MaterialManager.Contracts.Material.Boards
         /// </summary>
         [JsonProperty(Order = 36)]
         public string? Gtin { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the id from an external system.
+        /// </summary>
+        [JsonProperty(Order = 94)]
+        public string? ExternalId { get; set; }
 
         #endregion
 

--- a/Applications/MaterialManager/Contracts/Material/Edgebands/EdgebandType.cs
+++ b/Applications/MaterialManager/Contracts/Material/Edgebands/EdgebandType.cs
@@ -146,6 +146,11 @@ namespace HomagConnect.MaterialManager.Contracts.Material.Edgebands
         /// Gets or sets the gtin.
         /// </summary>
         public string? Gtin { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the id from an external system.
+        /// </summary>
+        public string? ExternalId { get; set; }
 
         #endregion
 


### PR DESCRIPTION
intelliDivide is switching to the new endpoints of intelliSettingsServiceApi.
The property ExternalId is relevant for their internal logic, so we should provide it