### PR TITLE
feat: get edgebands by edgebandCode postman collection

### DIFF
--- a/Applications/MaterialManager/Samples/Postman/Homag Connect materialManager.postman_collection.json
+++ b/Applications/MaterialManager/Samples/Postman/Homag Connect materialManager.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7054330e-849c-45e4-9a78-fbd936e537d0",
+		"_postman_id": "76cd50e7-b2be-4523-bbbc-c7948a0bd430",
 		"name": "Homag Connect materialManager",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -250,7 +250,7 @@
 									],
 									"query": [
 										{
-											"key": "edgebandCodes",
+											"key": "edgebandCode",
 											"value": "Test",
 											"disabled": true
 										},


### PR DESCRIPTION
Fixed wrong query parameter leading to the endpoint not consider the provided edgeband codes