### PR TITLE
Feature/318486 Adjust temporary disabled tests

### DIFF
--- a/Applications/IntelliDivide/Tests/Materials/MaterialsTests.cs
+++ b/Applications/IntelliDivide/Tests/Materials/MaterialsTests.cs
@@ -8,7 +8,7 @@ namespace HomagConnect.IntelliDivide.Tests.Materials
     [TestClass]
     [TestCategory("IntelliDivide")]
     [TestCategory("IntelliDivide.Materials")]
-    [TemporaryDisabledOnServer(2025, 3, 1, "DF-Optimization")] // Not yet on production server
+    [TemporaryDisabledOnServer(2025, 3, 5, "DF-Optimization")] // Not yet on production server
     public class MaterialsTests : IntelliDivideTestBase
     {
         [TestMethod]

--- a/Applications/IntelliDivide/Tests/Requests/Cutting/CuttingOptimizationRequestTests.cs
+++ b/Applications/IntelliDivide/Tests/Requests/Cutting/CuttingOptimizationRequestTests.cs
@@ -56,7 +56,7 @@ public class CuttingOptimizationRequestTests : IntelliDivideTestBase
 
     /// <summary />
     [TestMethod]
-    [TemporaryDisabledOnServer(2025,3, 1,"DF-Foundation")]
+    [TemporaryDisabledOnServer(2025,3, 5,"DF-Foundation")]
     public async Task BoardMaterial_GetBoardMaterialCategoryDisplayNames()
     {
         var intelliDivide = GetIntelliDivideClient();

--- a/Applications/IntelliDivide/Tests/Requests/Cutting/CuttingOptimizationRequestUsingObjectModelTests.cs
+++ b/Applications/IntelliDivide/Tests/Requests/Cutting/CuttingOptimizationRequestUsingObjectModelTests.cs
@@ -64,6 +64,7 @@ public class CuttingOptimizationRequestUsingObjectModelTests : IntelliDivideTest
 
     /// <summary />
     [TestMethod]
+    [TemporaryDisabledOnServer(2025, 3, 5, "DF-Optimization")]
     public async Task CuttingRequest_ObjectModel_TypicalProperties_ImportOptimizeAndSend()
     {
         var intelliDivide = GetIntelliDivideClient();

--- a/Applications/OrderManager/Client/OrderManagerClient.cs
+++ b/Applications/OrderManager/Client/OrderManagerClient.cs
@@ -55,7 +55,7 @@ namespace HomagConnect.OrderManager.Client
             var uris = orderState
                 .Select(o => $"&orderStatus={Uri.EscapeDataString(o.ToString())}")
                 .Join(QueryParametersMaxLength)
-                .Select(c => $"/api/productionManager/orders?take={take}&skip={skip}" + c)
+                .Select(c => $"/api/orderManager/orders?take={take}&skip={skip}" + c)
                 .Select(c => new Uri(c, UriKind.Relative));
 
             return await RequestEnumerableAsync<OrderOverview>(uris);

--- a/Applications/OrderManager/Tests/Import/ImportOrderTests.cs
+++ b/Applications/OrderManager/Tests/Import/ImportOrderTests.cs
@@ -17,7 +17,7 @@ namespace HomagConnect.OrderManager.Tests.Import
     [TestClass]
     [TestCategory("OrderManager")]
     [TestCategory("OrderManager.Orders.Import")]
-    [TemporaryDisabledOnServer(2025, 03, 1, "DF-Production")]
+    [TemporaryDisabledOnServer(2025, 04, 1, "DF-Production")]
     public class ImportOrderTests : OrderManagerTestBase
     {
         /// <summary />

--- a/Applications/OrderManager/Tests/Orders/GetOrderTests.cs
+++ b/Applications/OrderManager/Tests/Orders/GetOrderTests.cs
@@ -22,7 +22,7 @@ namespace HomagConnect.OrderManager.Tests.Orders
     {
         /// <summary />
         [TestMethod]
-        [TemporaryDisabledOnServer(2025, 03, 1, "DF-Production")]
+        [TemporaryDisabledOnServer(2025, 03, 28, "DF-Production")]
         public async Task Orders_GetAllOrdersHavingStatusNew_NoException()
         {
             var orderManager = GetOrderManagerClient();
@@ -44,7 +44,7 @@ namespace HomagConnect.OrderManager.Tests.Orders
 
         /// <summary />
         [TestMethod]
-        [TemporaryDisabledOnServer(2025, 03, 28, "DF-Optimization")]
+        [TemporaryDisabledOnServer(2025, 03, 28, "DF-Production")]
         public async Task Orders_GetAllOrdersHavingStatusNewOrInProduction_NoException()
         {
             var orderManager = GetOrderManagerClient();
@@ -66,7 +66,7 @@ namespace HomagConnect.OrderManager.Tests.Orders
 
         /// <summary />
         [TestMethod]
-        [TemporaryDisabledOnServer(2025, 03, 1, "DF-Production")]
+        [TemporaryDisabledOnServer(2025, 03, 28, "DF-Production")]
         public async Task Orders_GetAllOrders_NoException()
         {
             var orderManager = GetOrderManagerClient();

--- a/Applications/ProductionAssist/Tests/Authentication/AuthenticationTests.cs
+++ b/Applications/ProductionAssist/Tests/Authentication/AuthenticationTests.cs
@@ -1,12 +1,10 @@
-﻿using HomagConnect.Base.TestBase.Attributes;
-using HomagConnect.ProductionAssist.Samples.Authentication;
+﻿using HomagConnect.ProductionAssist.Samples.Authentication;
 
 namespace HomagConnect.ProductionAssist.Tests.Authentication
 {
     [TestClass]
     [TestCategory("ProductionAssist")]
     [TestCategory("ProductionAssist.Authentication")]
-    [TemporaryDisabledOnServer(2024, 9, 1, "DF-Production")]
     public class AuthenticationTests : ProductionAssistTestBase
     {
 #pragma warning disable S2699 // Tests should include assertions

--- a/Applications/ProductionManager/Tests/Orders/Actions/GetOrderTests.cs
+++ b/Applications/ProductionManager/Tests/Orders/Actions/GetOrderTests.cs
@@ -149,7 +149,6 @@ namespace HomagConnect.ProductionManager.Tests.Orders.Actions
 
         /// <summary />
         [TestMethod]
-        [TemporaryDisabledOnServer(2025, 12, 28, "DF-Optimization")]
         public async Task Orders_GetOrder_NoException()
         {
             // Create new instance of the ProductionManager client:


### PR DESCRIPTION
Enable all pM, pA connect tests.
Temporary Disable oM tests untill current oM and API GW are deployed to PROD