### PR TITLE
feat: Change endpoints return types

### DIFF
--- a/Applications/MaterialAssist/Client/MaterialAssistClientBoards.cs
+++ b/Applications/MaterialAssist/Client/MaterialAssistClientBoards.cs
@@ -102,9 +102,7 @@ namespace HomagConnect.MaterialAssist.Client
         /// <inheritdoc />
         public async Task<BoardEntity> GetBoardEntityById(string id)
         {
-            var url = $"{_BaseRouteMaterialAssist}?{_Id}={Uri.EscapeDataString(id)}";
-
-            return await RequestObject<BoardEntity>(new Uri(url, UriKind.Relative));
+            return await GetBoardEntitiesByIds([id]).FirstOrDefaultAsync();
         }
 
         /// <inheritdoc />

--- a/Applications/MaterialAssist/Client/MaterialAssistClientEdgebands.cs
+++ b/Applications/MaterialAssist/Client/MaterialAssistClientEdgebands.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+
 using HomagConnect.Base.Contracts;
 using HomagConnect.Base.Extensions;
 using HomagConnect.Base.Services;
@@ -58,7 +59,7 @@ namespace HomagConnect.MaterialAssist.Client
 
             throw new Exception($"The returned object is not of type {nameof(EdgebandType)}");
         }
-        
+
         /// <inheritdoc />
         public async Task<EdgebandEntity> CreateEdgebandEntity(MaterialAssistRequestEdgebandEntity edgebandEntityRequest)
         {
@@ -156,9 +157,7 @@ namespace HomagConnect.MaterialAssist.Client
         /// <inheritdoc />
         public async Task<EdgebandEntity> GetEdgebandEntityById(string id)
         {
-            var url = $"{_BaseRouteMaterialAssist}?{_Id}={Uri.EscapeDataString(id)}";
-
-            return await RequestObject<EdgebandEntity>(new Uri(url, UriKind.Relative));
+            return await GetEdgebandEntitiesByIds([id]).FirstOrDefaultAsync();
         }
 
         /// <inheritdoc />

--- a/Applications/MaterialManager/Client/MaterialManagerClientMaterialBoards.cs
+++ b/Applications/MaterialManager/Client/MaterialManagerClientMaterialBoards.cs
@@ -182,17 +182,13 @@ public class MaterialManagerClientMaterialBoards : ServiceBase, IMaterialManager
     /// <inheritdoc />
     public async Task<BoardType> GetBoardTypeByBoardCode(string boardCode)
     {
-        var url = $"{_BaseRoute}?{_BoardCode}={Uri.EscapeDataString(boardCode)}";
-
-        return await RequestObject<BoardType>(new Uri(url, UriKind.Relative));
+        return await GetBoardTypesByBoardCodes([boardCode]).FirstOrDefaultAsync();
     }
 
     /// <inheritdoc />
     public async Task<BoardTypeDetails> GetBoardTypeByBoardCodeIncludingDetails(string boardCode)
     {
-        var url = $"{_BaseRoute}?{_BoardCode}={Uri.EscapeDataString(boardCode)}&{_IncludingDetails}=true";
-
-        return await RequestObject<BoardTypeDetails>(new Uri(url, UriKind.Relative));
+        return await GetBoardTypesByBoardCodesIncludingDetails([boardCode]).FirstOrDefaultAsync();
     }
 
     /// <inheritdoc />

--- a/Applications/MaterialManager/Client/MaterialManagerClientMaterialEdgebands.cs
+++ b/Applications/MaterialManager/Client/MaterialManagerClientMaterialEdgebands.cs
@@ -50,17 +50,13 @@ public class MaterialManagerClientMaterialEdgebands : ServiceBase, IMaterialMana
     /// <inheritdoc />
     public async Task<EdgebandType> GetEdgebandTypeByEdgebandCode(string edgebandCode)
     {
-        var url = $"{_BaseRoute}?{_EdgebandCode}={Uri.EscapeDataString(edgebandCode)}";
-
-        return await RequestObject<EdgebandType>(new Uri(url, UriKind.Relative));
+        return await GetEdgebandTypesByEdgebandCodes([edgebandCode]).FirstOrDefaultAsync();
     }
 
     /// <inheritdoc />
     public async Task<EdgebandTypeDetails> GetEdgebandTypeByEdgebandCodeIncludingDetails(string edgebandCode)
     {
-        var url = $"{_BaseRoute}?{_EdgebandCode}={Uri.EscapeDataString(edgebandCode)}&{_IncludingDetails}=true";
-
-        return await RequestObject<EdgebandTypeDetails>(new Uri(url, UriKind.Relative));
+        return await GetEdgebandTypesByEdgebandCodesIncludingDetails([edgebandCode]).FirstOrDefaultAsync();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
We want to ensure all Get endpoints return arrays, especially empty arrays instead of null. 
HGConnect clients are adjusted.
Additional changes will be made in the backend so that all response types are Enumerables instead of Objects.