### PR TITLE
feat: implement technology macros in hg connect

### DIFF
--- a/Applications/MaterialManager/Client/MaterialManagerClientMaterialEdgebands.cs
+++ b/Applications/MaterialManager/Client/MaterialManagerClientMaterialEdgebands.cs
@@ -11,6 +11,7 @@ using HomagConnect.Base;
 using HomagConnect.Base.Contracts;
 using HomagConnect.Base.Extensions;
 using HomagConnect.Base.Services;
+using HomagConnect.MaterialManager.Contracts.Common;
 using HomagConnect.MaterialManager.Contracts.Material.Edgebands;
 using HomagConnect.MaterialManager.Contracts.Material.Edgebands.Interfaces;
 using HomagConnect.MaterialManager.Contracts.Request;
@@ -136,6 +137,25 @@ public class MaterialManagerClientMaterialEdgebands : ServiceBase, IMaterialMana
     public Task<IEnumerable<EdgeInventoryHistory>> GetEdgebandTypeInventoryHistoryAsync(int daysBack)
     {
         return GetEdgebandTypeInventoryHistoryAsync(DateTime.Now.AddDays(-daysBack), DateTime.Now);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<string>> GetTechnologyMacrosFromMachine(string tapioMachineId)
+    {
+        if (tapioMachineId == null)
+        {
+            throw new ArgumentNullException(nameof(tapioMachineId));
+        }
+
+        var url = $"{_BaseRoute}/macros?tapioMachineId={Uri.EscapeDataString(tapioMachineId)}";
+        return await RequestEnumerable<string>(new Uri(url, UriKind.Relative));
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TapioMachine>> GetLicensedMachines()
+    {
+        const string url = $"{_BaseRoute}/machines";
+        return await RequestEnumerable<TapioMachine>(new Uri(url, UriKind.Relative));
     }
 
     #region Update

--- a/Applications/MaterialManager/Contracts/Common/TapioMachine.cs
+++ b/Applications/MaterialManager/Contracts/Common/TapioMachine.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+
+namespace HomagConnect.MaterialManager.Contracts.Common;
+
+/// <summary>
+/// Machine which is licensed for the materials api.
+/// </summary>
+[DebuggerDisplay("{Name}")]
+public class TapioMachine
+{
+    /// <summary>
+    /// Gets the name of the machine.
+    /// </summary>
+    public string Name { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets the tapio machine id of the machine.
+    /// </summary>
+    public string TapioMachineId { get; } = string.Empty;
+}

--- a/Applications/MaterialManager/Contracts/Material/Edgebands/EdgebandType.cs
+++ b/Applications/MaterialManager/Contracts/Material/Edgebands/EdgebandType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Runtime.Serialization;
@@ -109,9 +110,15 @@ public class EdgebandType : IExtensibleDataObject, IContainsUnitSystemDependentP
     public double? FunctionLayerThickness { get; set; }
 
     /// <summary>
-    /// Gets or sets the macro name.
+    /// Gets or sets the technology macro name.
     /// </summary>
-    public string? MacroName { get; set; }
+    [StringLength(50)]
+    public string? TechnologyMacro { get; set; }
+
+    /// <summary>
+    /// Gets or sets the technology macro name by tapio machine id as the key.
+    /// </summary>
+    public IDictionary<string, string>? MachineTechnologyMacro { get; set; }
 
     #endregion
 

--- a/Applications/MaterialManager/Contracts/Material/Edgebands/Interfaces/IMaterialManagerClientMaterialEdgebands.cs
+++ b/Applications/MaterialManager/Contracts/Material/Edgebands/Interfaces/IMaterialManagerClientMaterialEdgebands.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using HomagConnect.Base.Contracts;
+using HomagConnect.MaterialManager.Contracts.Common;
 using HomagConnect.MaterialManager.Contracts.Material.Boards;
 using HomagConnect.MaterialManager.Contracts.Request;
 using HomagConnect.MaterialManager.Contracts.Statistics;
@@ -50,6 +51,17 @@ namespace HomagConnect.MaterialManager.Contracts.Material.Edgebands.Interfaces
         /// Get <see cref="EdgeInventoryHistory" /> inventory history for edgebands<see cref="EdgebandType" />.
         /// </summary>
         Task<IEnumerable<EdgeInventoryHistory>> GetEdgebandTypeInventoryHistoryAsync(int daysBack);
+
+        /// <summary>
+        /// Get all technology macros for a machine.
+        /// </summary>
+        /// <param name="tapioMachineId">The machine id from tapio.</param>
+        Task<IEnumerable<string>> GetTechnologyMacrosFromMachine(string tapioMachineId);
+
+        /// <summary>
+        /// Get all <see cref="TapioMachine" /> licensed for material api. />.
+        /// </summary>
+        Task<IEnumerable<TapioMachine>> GetLicensedMachines();
 
         /// <summary>
         /// Gets all edgebands.

--- a/Applications/MaterialManager/Contracts/Request/MaterialManagerRequestEdgebandType.cs
+++ b/Applications/MaterialManager/Contracts/Request/MaterialManagerRequestEdgebandType.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 using HomagConnect.Base.Contracts.Attributes;
@@ -61,10 +62,9 @@ public class MaterialManagerRequestEdgebandType : MaterialManagerRequestMaterial
     public double? Lasertec { get; set; }
 
     /// <summary>
-    /// Gets or sets the macro name.
+    /// Gets or sets the technology macro name by tapio machine id as the key.
     /// </summary>
-    [StringLength(50)]
-    public string? MacroName { get; set; }
+    public IDictionary<string, string>? MachineTechnologyMacro { get; set; }
 
     /// <summary>
     /// Gets or sets the material category.
@@ -84,6 +84,12 @@ public class MaterialManagerRequestEdgebandType : MaterialManagerRequestMaterial
     [ValueDependsOnUnitSystem(BaseUnit.Millimeter, 2, 3)]
     [Range(0, double.PositiveInfinity)]
     public double? ProtectionFilmThickness { get; set; }
+
+    /// <summary>
+    /// Gets or sets the technology macro name.
+    /// </summary>
+    [StringLength(50)]
+    public string? TechnologyMacro { get; set; }
 
     /// <summary>
     /// Gets or sets the thickness of the edgeband. The unit depends on the settings of the subscription (metric: mm, imperial:

--- a/Applications/MaterialManager/Contracts/Update/MaterialManagerUpdateEdgebandType.cs
+++ b/Applications/MaterialManager/Contracts/Update/MaterialManagerUpdateEdgebandType.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 using HomagConnect.Base.Contracts.Attributes;
@@ -58,10 +59,9 @@ public class MaterialManagerUpdateEdgebandType : MaterialManagerUpdateMaterialTy
     public double? Lasertec { get; set; }
 
     /// <summary>
-    /// Gets or sets the macro name.
+    /// Gets or sets the technology macro name by tapio machine id as the key.
     /// </summary>
-    [StringLength(50)]
-    public string? MacroName { get; set; }
+    public IDictionary<string, string>? MachineTechnologyMacro { get; set; }
 
     /// <summary>
     /// Gets or sets the material category.
@@ -79,6 +79,12 @@ public class MaterialManagerUpdateEdgebandType : MaterialManagerUpdateMaterialTy
     [ValueDependsOnUnitSystem(BaseUnit.Millimeter, 2, 3)]
     [Range(0, double.PositiveInfinity)]
     public double? ProtectionFilmThickness { get; set; }
+
+    /// <summary>
+    /// Gets or sets the technology macro name.
+    /// </summary>
+    [StringLength(50)]
+    public string? TechnologyMacro { get; set; }
 
     /// <summary>
     /// Gets or sets the thickness of the edgeband. The unit depends on the settings of the subscription (metric: mm, imperial:

--- a/Applications/MaterialManager/Samples/Create/Edgebands/Readme.md
+++ b/Applications/MaterialManager/Samples/Create/Edgebands/Readme.md
@@ -1,8 +1,10 @@
-<h1 id="createEdgebandType"> Create edgeband type</h1>
+# Create edgeband type
 
 With the HOMAG Connect materialManager edgebands client, new edgeband types can be created.
 
-<strong>Example:</strong>
+## CreateEdgebandType
+
+**Example:**
 
 ```csharp
 // Create new instance of the materialManager client:
@@ -26,3 +28,28 @@ var newEdgebandType = await client.CreateEdgebandType(edgebandTypeRequest);
 // Use the created edgeband type for further processing
 Console.WriteLine($"Created Edgeband Type: {newEdgebandType.Code}");
 ```
+
+## CreateEdgebandType with technology macro
+
+```csharp
+var client = new MaterialManagerClientMaterialEdgebands(subscriptionId, authorizationKey);
+
+var edgebandTypeUpdate = new MaterialManagerUpdateEdgebandType
+{
+    EdgebandCode = "EB_White_1mm",
+    Height = 20,
+    Thickness = 1.0,
+    DefaultLength = 23.0,
+    MaterialCategory = EdgebandMaterialCategory.Veneer,
+    Process = Process.Other,    
+    MachineTechnologyMacro = new Dictionary<string, string>
+    {
+        { "hg0000000000", "ABS_1.00_RM_HM"}
+    },
+    // other properties
+};
+
+var newEdgebandType = await client.CreateEdgebandType(edgebandTypeRequest);
+```
+
+Available technology macro names and machines can be requested within the same client.

--- a/Applications/MaterialManager/Samples/Postman/Homag Connect materialManager.postman_collection.json
+++ b/Applications/MaterialManager/Samples/Postman/Homag Connect materialManager.postman_collection.json
@@ -426,7 +426,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"edgebandCode\": \"string\",\r\n  \"thickness\": 1.2,\r\n  \"height\": 23,\r\n  \"defaultLength\": 150,\r\n  \"articleNumber\": \"string\",\r\n  \"comments\": \"string\",\r\n  \"costs\": 10,\r\n  \"decorCode\": \"string\",\r\n  \"decorName\": \"string\",\r\n  \"manufacturerName\": \"string\",\r\n  \"productName\": \"string\",\r\n  \"thumbnail\": \"string\",\r\n  \"materialCategory\": \"abs\",\r\n  \"process\": \"Zerojoint\",\r\n  \"lasertec\": 0,\r\n  \"airtec\": 0,\r\n  \"protectionFilmThickness\": 0,\r\n  \"functionLayerThickness\": 0,\r\n  \"macroName\": \"string\",\r\n  \"decorEmbossingCode\": \"string\"\r\n}",
+							"raw": "{\r\n  \"edgebandCode\": \"string\",\r\n  \"thickness\": 1.2,\r\n  \"height\": 23,\r\n  \"defaultLength\": 150,\r\n  \"articleNumber\": \"string\",\r\n  \"comments\": \"string\",\r\n  \"costs\": 10,\r\n  \"decorCode\": \"string\",\r\n  \"decorName\": \"string\",\r\n  \"manufacturerName\": \"string\",\r\n  \"productName\": \"string\",\r\n  \"thumbnail\": \"string\",\r\n  \"materialCategory\": \"abs\",\r\n  \"process\": \"Zerojoint\",\r\n  \"lasertec\": 0,\r\n  \"airtec\": 0,\r\n  \"protectionFilmThickness\": 0,\r\n  \"functionLayerThickness\": 0,\r\n  \"technologyMacro\": \"string\",\r\n  \"decorEmbossingCode\": \"string\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -504,7 +504,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"articleNumber\": \"string\",\r\n  \"gtin\": \"string\",\r\n  \"comments\": \"string\",\r\n  \"costs\": 0,\r\n  \"decorCode\": \"string\",\r\n  \"decorName\": \"string\",\r\n  \"manufacturerName\": \"string\",\r\n  \"productName\": \"string\",\r\n  \"thumbnail\": \"string\",\r\n  \"airtec\": 0,\r\n  \"decorEmbossingCode\": \"string\",\r\n  \"edgebandCode\": \"string\",\r\n  \"functionLayerThickness\": 0,\r\n  \"process\": 0,\r\n  \"height\": 999.9,\r\n  \"lasertec\": 0,\r\n  \"defaultLength\": 9999.9,\r\n  \"macroName\": \"string\",\r\n  \"materialCategory\": 0,\r\n  \"protectionFilmThickness\": 0,\r\n  \"thickness\": 99.9,\r\n  \"totalLengthAvailableWarningLimit\": 0,\r\n  \"totalQuantityAvailableWarningLimit\": 2147483647\r\n}",
+									"raw": "{\r\n  \"articleNumber\": \"string\",\r\n  \"gtin\": \"string\",\r\n  \"comments\": \"string\",\r\n  \"costs\": 0,\r\n  \"decorCode\": \"string\",\r\n  \"decorName\": \"string\",\r\n  \"manufacturerName\": \"string\",\r\n  \"productName\": \"string\",\r\n  \"thumbnail\": \"string\",\r\n  \"airtec\": 0,\r\n  \"decorEmbossingCode\": \"string\",\r\n  \"edgebandCode\": \"string\",\r\n  \"functionLayerThickness\": 0,\r\n  \"process\": 0,\r\n  \"height\": 999.9,\r\n  \"lasertec\": 0,\r\n  \"defaultLength\": 9999.9,\r\n  \"technologyMacro\": \"string\",\r\n  \"materialCategory\": 0,\r\n  \"protectionFilmThickness\": 0,\r\n  \"thickness\": 99.9,\r\n  \"totalLengthAvailableWarningLimit\": 0,\r\n  \"totalQuantityAvailableWarningLimit\": 2147483647\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/Applications/MaterialManager/Samples/Read/Edgebands/Readme.md
+++ b/Applications/MaterialManager/Samples/Read/Edgebands/Readme.md
@@ -2,7 +2,9 @@
 
 With the HOMAG Connect materialManager edgebands client, the edgebands related data can be retrieved from materialManager for further programmatic evaluation.
 
-<strong>Example:</strong>
+## GetEdgebandTypes
+
+**Example:**
 
 ```csharp
 // Create new instance of the materialManager client:
@@ -12,8 +14,73 @@ var client = new MaterialManagerClientMaterialEdgebands(subscriptionId, authoriz
 var edgebandCodes = new List<string> { "ABS_Abruzzo_colore_1.00_100.0_HM", "ACR_Buche_mit_Silberstreifen_2.00_43.0_HM" };
 
 // Get the data
-var edgebandTypes = client.GetEdgebandsTypes(edgebandCodes);
+var edgebandTypes = client.GetEdgebandTypes(edgebandCodes);
 
 // Use the retrieved data for further processing
 
+```
+
+## GetLicensedMachines
+
+Get the machine information of machines in tapio licensed for the materials api. This can be used to get and set the technology macros.
+
+**Example:**
+
+```csharp
+// Create new instance of the materialManager client:
+var client = new MaterialManagerClientMaterialEdgebands(subscriptionId, authorizationKey);
+
+// Get the data
+var tapioMachines = client.GetLicensedMachines();
+```
+
+**Returns:**
+
+```csharp
+public class TapioMachine
+{
+    /// <summary>
+    /// Gets the name of the machine.
+    /// </summary>
+    public string Name { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets the tapio machine id of the machine.
+    /// </summary>
+    public string TapioMachineId { get; } = string.Empty;
+}
+```
+
+## GetTechnologyMacrosFromMachine
+
+Technology macros can be set explicitly for a machine when [creating](../../Create/Edgebands/Readme.md) or [updating](../../Update/Edgebands/Readme.md) an `EdgebandType`. This is required when materialManager works together with the HOMAG woodCommander Software.
+
+The `EdgebandType` and its update and reate objects contain these macro properties:
+
+```csharp
+    /// <summary>
+    /// Gets or sets the technology macro name by tapio machine id as the key.
+    /// </summary>
+    public IDictionary<string, string>? MachineTechnologyMacro { get; set; }
+
+    /// <summary>
+    /// Gets or sets the technology macro name.
+    /// </summary>
+    [StringLength(50)]
+    public string? TechnologyMacro { get; set; }
+```
+
+The `TechnologyMacro` sets a macro name for machines before woodCommander 5 or without capability of setting a macro specifically.
+With `MachineTechnologyMacro` and woodCommander 5 you can set a macro specifically for one machine.
+
+With `GetTechnologyMacrosFromMachine` the available technology macro names can be requested for a given tapio machine id.
+
+**Example:**
+
+```csharp
+// Create new instance of the materialManager client:
+var client = new MaterialManagerClientMaterialEdgebands(subscriptionId, authorizationKey);
+
+// Get the data
+var technologyMacros = client.GetTechnologyMacrosFromMachine(tapioMachineId);
 ```

--- a/Applications/MaterialManager/Samples/Read/Edgebands/Readme.md
+++ b/Applications/MaterialManager/Samples/Read/Edgebands/Readme.md
@@ -55,7 +55,7 @@ public class TapioMachine
 
 Technology macros can be set explicitly for a machine when [creating](../../Create/Edgebands/Readme.md) or [updating](../../Update/Edgebands/Readme.md) an `EdgebandType`. This is required when materialManager works together with the HOMAG woodCommander Software.
 
-The `EdgebandType` and its update and reate objects contain these macro properties:
+The `EdgebandType` and its update and create objects contain these macro properties:
 
 ```csharp
     /// <summary>

--- a/Applications/MaterialManager/Samples/Update/Edgebands/Readme.md
+++ b/Applications/MaterialManager/Samples/Update/Edgebands/Readme.md
@@ -1,8 +1,10 @@
 # Update edgeband type
 
-With the HOMAG Connect materialManager edgebands client, existing edgeband types can be updated. 
+With the HOMAG Connect materialManager edgebands client, existing edgeband types can be updated.
 
-<strong>Example:</strong>
+## UpdateEdgebandType
+
+**Example:**
 
 ```csharp
 // Create new instance of the materialManager client:
@@ -21,3 +23,23 @@ var updatedEdgebandType = await client.UpdateEdgebandType("EB_White_1mm", edgeba
 // Use the updated edgeband type for further processing
 Console.WriteLine($"Updated Edgeband Type: {updatedEdgebandType.Code}");
 ```
+
+## UpdateEdgebandType with technology macro
+
+```csharp
+var client = new MaterialManagerClientMaterialEdgebands(subscriptionId, authorizationKey);
+
+var edgebandTypeUpdate = new MaterialManagerUpdateEdgebandType
+{
+    // other properties
+    MachineTechnologyMacro = new Dictionary<string, string>
+    {
+        { "hg0000000000", "ABS_1.00_RM_HM"}
+    },
+    // other properties
+};
+
+var updatedEdgebandType = await client.UpdateEdgebandType("ABS_White_1mm", edgebandTypeUpdate);
+```
+
+Available technology macro names and machines can be requested within the same client.

--- a/Applications/MaterialManager/Tests/Material/Edgebands/EdgebandTypeTests.cs
+++ b/Applications/MaterialManager/Tests/Material/Edgebands/EdgebandTypeTests.cs
@@ -90,6 +90,31 @@ public class EdgebandTypeTests : MaterialManagerTestBase
         Assert.AreNotEqual(edgebandTypeMetric.TotalLengthAvailableWarningLimit, edgebandTypeImperial.TotalLengthAvailableWarningLimit);
     }
 
+    /// <summary />
+    [TestMethod]
+    [TemporaryDisabledOnServer(2025, 3, 15, "DF-Material")]
+    public async Task Machines_GetAll_ReturnsData()
+    {
+        var materialManagerClient = GetMaterialManagerClient();
+
+        var machines = await materialManagerClient.Material.Edgebands.GetLicensedMachines();
+
+        machines.Should().NotBeNullOrEmpty("Machines should be assigned to test subscription.");
+    }
+    
+    /// <summary />
+    [TestMethod]
+    [TemporaryDisabledOnServer(2025, 3, 15, "DF-Material")]
+    public async Task TechnologyMacros_GetByMachine_ReturnsData()
+    {
+        var materialManagerClient = GetMaterialManagerClient();
+
+        var machines = await materialManagerClient.Material.Edgebands.GetLicensedMachines();
+        var macros = await materialManagerClient.Material.Edgebands.GetTechnologyMacrosFromMachine(machines.First().TapioMachineId);
+        
+        macros.Should().NotBeNull();
+    }
+
     private static async Task EdgebandType_CreateEdgebandType_Cleanup(MaterialManagerClient materialManagerClient, string edgebandCode)
     {
         var existingEdgebandTypes = await materialManagerClient.Material.Edgebands.GetEdgebandTypesByEdgebandCodes([edgebandCode]);


### PR DESCRIPTION
The feature "macro scope" allows the user in mM to set a macro for a specific machine.

This is done by a key - value combination of tmid and the unique macro name.

Both can be requested from our API.