### PR TITLE
Feature/363338 prod flow

### DIFF
--- a/.github/workflows/config/linkspector.yml
+++ b/.github/workflows/config/linkspector.yml
@@ -6,4 +6,5 @@ ignorePatterns:
 aliveStatusCodes:
 - 200
 - 401
+- 403
 - 999

--- a/Applications/ProductionAssist/Contracts/Workstation.cs
+++ b/Applications/ProductionAssist/Contracts/Workstation.cs
@@ -1,5 +1,4 @@
-﻿using HomagConnect.Base.Contracts.Enumerations;
-using HomagConnect.Base.Contracts.Interfaces;
+﻿using HomagConnect.Base.Contracts.Interfaces;
 
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations;
@@ -9,7 +8,7 @@ namespace HomagConnect.ProductionAssist.Contracts;
 /// <summary>
 /// Workstation
 /// </summary>
-public class Workstation:ISupportsLocalizedSerialization
+public class Workstation: Base.Contracts.Workstation, ISupportsLocalizedSerialization
 {
     /// <summary>
     /// Gets or sets the tapio machine ID
@@ -22,27 +21,6 @@ public class Workstation:ISupportsLocalizedSerialization
     /// Gets or sets the display name
     /// </summary>
     [JsonProperty(Order = 2)]
-    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(DisplayName))]
+    [Obsolete("This property is obsolete. Use the new Name property instead.", true)]
     public string DisplayName { get; set; }
-
-    /// <summary>
-    /// Gets or sets the tapio machine ID
-    /// </summary>
-    [JsonProperty(Order = 3)]
-    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(Group))]
-    public WorkstationGroup Group { get; set; } = WorkstationGroup.None;
-
-    /// <summary>
-    /// Gets or sets the Workstation Id
-    /// </summary>
-    [JsonProperty(Order = 1)]
-    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(Id))]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Gets or sets the tapio machine ID
-    /// </summary>
-    [JsonProperty(Order = 4)]
-    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(Type))]
-    public WorkstationType Type { get; set; } = WorkstationType.None;
 }

--- a/Applications/ProductionAssist/Contracts/Workstation.cs
+++ b/Applications/ProductionAssist/Contracts/Workstation.cs
@@ -22,5 +22,9 @@ public class Workstation: Base.Contracts.Workstation, ISupportsLocalizedSerializ
     /// </summary>
     [JsonProperty(Order = 2)]
     [Obsolete("This property is obsolete. Use the new Name property instead.", true)]
-    public string DisplayName { get; set; }
+    public string DisplayName
+    {
+        get { return Name; }
+        set { Name = value; }
+    }
 }

--- a/Applications/ProductionAssist/Tests/Events/WorkstationEventTests.cs
+++ b/Applications/ProductionAssist/Tests/Events/WorkstationEventTests.cs
@@ -90,7 +90,7 @@ public class WorkstationEventTests : ProductionAssistTestBase
         workstationUpsertedEvent.Workstation = new Workstation 
         { 
             Id = Guid.NewGuid(),
-            DisplayName = "TestMachine",
+            Name = "TestMachine",
             Type = WorkstationType.Cutting,
         };
         workstationUpsertedEvent.Trace();
@@ -111,7 +111,7 @@ public class WorkstationEventTests : ProductionAssistTestBase
         workstationUpsertedEvent.Workstation = new Workstation
         {
             Id = Guid.NewGuid(),
-            DisplayName = "TestMachine",
+            Name = "TestMachine",
             Type = WorkstationType.Cutting,
         };
         workstationUpsertedEvent.Action = UpsertAction.Updated;

--- a/Applications/ProductionAssist/Tests/Feedback/ProductionAssistFeedbackTests.cs
+++ b/Applications/ProductionAssist/Tests/Feedback/ProductionAssistFeedbackTests.cs
@@ -44,7 +44,7 @@ namespace HomagConnect.ProductionAssist.Tests.Feedback
             var workstation = JsonConvert.DeserializeObject<FeedbackWorkstation>(oldJson);
 
             Assert.AreEqual(id, workstation?.Id);
-            Assert.AreEqual(name, workstation?.DisplayName);
+            Assert.AreEqual(name, workstation?.Name);
 
             // new properties should have default enum values
             Assert.AreEqual(default(WorkstationGroup), workstation.Group);

--- a/Applications/ProductionManager/Client/ProductionManagerClient.cs
+++ b/Applications/ProductionManager/Client/ProductionManagerClient.cs
@@ -9,7 +9,6 @@ using HomagConnect.ProductionManager.Contracts.Orders;
 using HomagConnect.ProductionManager.Contracts.Predict;
 using HomagConnect.ProductionManager.Contracts.ProductionItems;
 using HomagConnect.ProductionManager.Contracts.ProductionProtocol;
-using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
 using HomagConnect.ProductionManager.Contracts.Rework;
 using Newtonsoft.Json;
 using System;
@@ -21,6 +20,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+
+using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
 
 namespace HomagConnect.ProductionManager.Client
 {

--- a/Applications/ProductionManager/Client/ProductionManagerClient.cs
+++ b/Applications/ProductionManager/Client/ProductionManagerClient.cs
@@ -9,6 +9,7 @@ using HomagConnect.ProductionManager.Contracts.Orders;
 using HomagConnect.ProductionManager.Contracts.Predict;
 using HomagConnect.ProductionManager.Contracts.ProductionItems;
 using HomagConnect.ProductionManager.Contracts.ProductionProtocol;
+using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
 using HomagConnect.ProductionManager.Contracts.Rework;
 using Newtonsoft.Json;
 using System;
@@ -649,6 +650,23 @@ namespace HomagConnect.ProductionManager.Client
         {
             string uri = "api/productionManager/orderprogress";
             return await PostObject<OrderProgressRequest, IEnumerable<OrderProgressDetails>>(new Uri(uri, UriKind.Relative), orderProgressRequest);
+        }
+
+        /// <inheritdoc />
+        public async Task<ProductionProtocolFlowDetails?> GetProductionFlow(DateTime from, DateTime? to)
+        {
+            var intTo = to ??DateTime.UtcNow;
+
+            var queryParameters = new List<string>
+            {
+                $"from={Uri.EscapeDataString(from.ToString("o", CultureInfo.InvariantCulture))}",
+                $"to={Uri.EscapeDataString(intTo.ToString("o", CultureInfo.InvariantCulture))}"
+            };
+
+            var url = $"/api/productionManager/productionprotocolflow?{string.Join("&", queryParameters)}";
+            var productionFlow = await RequestObject<ProductionProtocolFlowDetails>(new Uri(url, UriKind.Relative));
+
+            return productionFlow;
         }
         #endregion Usage statistics
 

--- a/Applications/ProductionManager/Contracts/IProductionManagerClient.cs
+++ b/Applications/ProductionManager/Contracts/IProductionManagerClient.cs
@@ -340,6 +340,14 @@ namespace HomagConnect.ProductionManager.Contracts
         /// </summary>
         /// <returns></returns>
         Task<IEnumerable<OrderProgressDetails>?> GetOrderProgress(OrderProgressRequest orderProgressRequest);
+
+        /// <summary>
+        /// Retrieves production protocol flow details for a specified duration.
+        /// </summary>  
+        /// <param name="from">The start date and time of the duration.</param>
+        /// <param name="to">The end date and time of the duration.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the production protocol flow details, or <see langword="null"/> if no data is found.</returns>
+        Task<ProductionProtocolFlowDetails?> GetProductionFlow(DateTime from, DateTime? to);
         #endregion Usage statistics
     }
 }

--- a/Applications/ProductionManager/Contracts/IProductionManagerClient.cs
+++ b/Applications/ProductionManager/Contracts/IProductionManagerClient.cs
@@ -6,6 +6,7 @@ using HomagConnect.ProductionManager.Contracts.Orders;
 using HomagConnect.ProductionManager.Contracts.Predict;
 using HomagConnect.ProductionManager.Contracts.ProductionItems;
 using HomagConnect.ProductionManager.Contracts.ProductionProtocol;
+using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
 using HomagConnect.ProductionManager.Contracts.Rework;
 
 namespace HomagConnect.ProductionManager.Contracts

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowDetails.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowDetails.cs
@@ -1,0 +1,25 @@
+﻿using HomagConnect.Base.Contracts;
+using HomagConnect.Base.Contracts.Enumerations;
+using HomagConnect.Base.Contracts.Interfaces;
+
+using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
+
+using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
+
+namespace HomagConnect.ProductionManager.Contracts.OrderProgress
+{
+    /// <summary>
+    /// get all Workstation details (like an aggregated Orderprogress)
+    /// plus all edges to the next Workstations with the aggregated quantity on this edge
+    /// </summary>
+    public class ProductionProtocolFlowDetails : ISupportsLocalizedSerialization
+    {
+        /// <summary>
+        /// List of all Workstations for graphical representation of the flow. The order of the list is not relevant, because the flow is defined by the edges in the Workstation details
+        /// </summary>
+        /// <example>4711</example>
+        [JsonProperty(Order = 1)]
+        public IEnumerable<ProductionProtocolFlowNode> Workstations { get; set; }
+    }
+}

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowDetails.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowDetails.cs
@@ -1,13 +1,8 @@
-﻿using HomagConnect.Base.Contracts;
-using HomagConnect.Base.Contracts.Enumerations;
-using HomagConnect.Base.Contracts.Interfaces;
+﻿using HomagConnect.Base.Contracts.Interfaces;
 
 using Newtonsoft.Json;
-using System.ComponentModel.DataAnnotations;
 
-using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
-
-namespace HomagConnect.ProductionManager.Contracts.OrderProgress
+namespace HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow
 {
     /// <summary>
     /// get all Workstation details (like an aggregated Orderprogress)
@@ -20,6 +15,6 @@ namespace HomagConnect.ProductionManager.Contracts.OrderProgress
         /// </summary>
         /// <example>4711</example>
         [JsonProperty(Order = 1)]
-        public IEnumerable<ProductionProtocolFlowNode> Workstations { get; set; }
+        public IEnumerable<ProductionProtocolFlowNode> Workstations { get; set; } = new List<ProductionProtocolFlowNode>();
     }
 }

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowEdge.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowEdge.cs
@@ -1,0 +1,25 @@
+using HomagConnect.Base.Contracts;
+using HomagConnect.Base.Contracts.Interfaces;
+using HomagConnect.ProductionManager.Contracts.ProductionItems;
+
+using Newtonsoft.Json;
+
+namespace HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
+
+/// <summary>
+/// 
+/// </summary>
+public class ProductionProtocolFlowEdge : ISupportsLocalizedSerialization
+{
+    /// <summary>
+    /// Data of one Workstation, that gets data from the current Workstation
+    /// </summary>
+    [JsonProperty(Order = 20)]
+    public Workstation? OutputWorkstation { get; set; }
+
+    /// <summary>
+    /// distribution of parts per type travelling on this edge
+    /// </summary>
+    [JsonProperty(Order = 2)]
+    public Dictionary<ProductionItemType, int>? ItemTypeSummary { get; set; }
+}

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowEdge.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowEdge.cs
@@ -18,8 +18,8 @@ public class ProductionProtocolFlowEdge : ISupportsLocalizedSerialization
     public Workstation? OutputWorkstation { get; set; }
 
     /// <summary>
-    /// distribution of parts per type travelling on this edge
+    /// Distribution of parts per type travelling on this edge
     /// </summary>
     [JsonProperty(Order = 2)]
-    public Dictionary<ProductionItemType, int>? ItemTypeSummary { get; set; }
+    public Dictionary<ProductionItemType, int> ItemTypeSummary { get; set; } = new();
 }

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowNode.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowNode.cs
@@ -1,0 +1,41 @@
+using HomagConnect.Base.Contracts;
+using HomagConnect.Base.Contracts.Interfaces;
+using HomagConnect.ProductionManager.Contracts.ProductionItems;
+
+using Newtonsoft.Json;
+
+namespace HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
+
+/// <summary>
+/// Workstation
+/// </summary>
+public class ProductionProtocolFlowNode : ISupportsLocalizedSerialization
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="itemTypeSummary"></param>
+    public ProductionProtocolFlowNode(Dictionary<ProductionItemType, int> itemTypeSummary)
+    {
+        ItemTypeSummary = itemTypeSummary;
+    }
+
+    /// <summary>
+    /// Gets or sets the tapio machine ID
+    /// </summary>
+    [JsonProperty(Order = 20)]
+    public Workstation? InputWorkstation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name
+    /// </summary>
+    [JsonProperty(Order = 21)]
+    public Dictionary<ProductionItemType, int> ItemTypeSummary { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonProperty(Order = 22)]
+    public IEnumerable<ProductionProtocolFlowEdge>? OutputWorkstations { get; set; }
+
+}

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowNode.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowNode.cs
@@ -33,7 +33,7 @@ public class ProductionProtocolFlowNode : ISupportsLocalizedSerialization
     public Dictionary<ProductionItemType, int> ItemTypeSummary { get; set; }
 
     /// <summary>
-    /// 
+    /// Edges are only prepared for future development, when the flow of each single instance is known
     /// </summary>
     [JsonProperty(Order = 22)]
     public IEnumerable<ProductionProtocolFlowEdge>? OutputWorkstations { get; set; }

--- a/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowNode.cs
+++ b/Applications/ProductionManager/Contracts/ProductionProtocolFlow/ProductionProtocolFlowNode.cs
@@ -12,25 +12,16 @@ namespace HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
 public class ProductionProtocolFlowNode : ISupportsLocalizedSerialization
 {
     /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="itemTypeSummary"></param>
-    public ProductionProtocolFlowNode(Dictionary<ProductionItemType, int> itemTypeSummary)
-    {
-        ItemTypeSummary = itemTypeSummary;
-    }
-
-    /// <summary>
     /// Gets or sets the tapio machine ID
     /// </summary>
     [JsonProperty(Order = 20)]
     public Workstation? InputWorkstation { get; set; }
 
     /// <summary>
-    /// Gets or sets the display name
+    /// Gets or sets the distribution of parts per type on this workstation
     /// </summary>
     [JsonProperty(Order = 21)]
-    public Dictionary<ProductionItemType, int> ItemTypeSummary { get; set; }
+    public Dictionary<ProductionItemType, int> ItemTypeSummary { get; set; } = new();
 
     /// <summary>
     /// Edges are only prepared for future development, when the flow of each single instance is known

--- a/Applications/ProductionManager/Samples/CSharp/ProductionProtocol/Actions/GetProductionFlowSamples.cs
+++ b/Applications/ProductionManager/Samples/CSharp/ProductionProtocol/Actions/GetProductionFlowSamples.cs
@@ -1,0 +1,43 @@
+using HomagConnect.Base.Extensions;
+using HomagConnect.ProductionManager.Contracts;
+using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
+
+namespace HomagConnect.ProductionManager.Samples.ProductionProtocol.Actions
+{
+    /// <summary>
+    /// Sample class which shows how to get the Production Flow for a specified duration.
+    /// </summary>
+    public static class GetProductionFlowSamples
+    {
+        /// <summary>
+        /// Gets the production flow for the last 7 days.
+        /// </summary>
+        public static async Task GetProductionFlowLast7Days(IProductionManagerClient productionManager)
+        {
+            // Get production flow for the last 7 days
+            var from = DateTime.UtcNow.AddDays(-7);
+            var to = DateTime.UtcNow;
+
+            var productionFlow = await productionManager.GetProductionFlow(from, to);
+
+            if (productionFlow?.Workstations != null)
+            {
+                var workstationCount = productionFlow.Workstations.Count();
+                var totalItems = productionFlow.Workstations
+                    .SelectMany(w => w.ItemTypeSummary.Values)
+                    .Sum();
+
+                var summary = new
+                {
+                    Period = $"{from:yyyy-MM-dd} to {to:yyyy-MM-dd}",
+                    WorkstationCount = workstationCount,
+                    TotalItems = totalItems
+                };
+
+                summary.Trace("Production Flow Summary");
+            }
+
+            productionFlow.Trace(nameof(productionFlow));
+        }
+    }
+}

--- a/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowIntegrationTests.cs
+++ b/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowIntegrationTests.cs
@@ -21,6 +21,7 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
         /// Tests getting production flow for the last 7 days.
         /// </summary>
         [TestMethod]
+        [TemporaryDisabledOnServer(2026, 07, 01, "DF-Insights")]
         public async Task GetProductionFlow_Last7Days_ReturnsData()
         {
             // Arrange

--- a/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowIntegrationTests.cs
+++ b/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowIntegrationTests.cs
@@ -1,0 +1,42 @@
+using HomagConnect.Base.Extensions;
+using HomagConnect.Base.TestBase.Attributes;
+
+using Shouldly;
+
+namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
+{
+    /// <summary>
+    /// Integration tests for Production Protocol Flow functionality.
+    /// </summary>
+    [TestClass]
+    [IntegrationTest("ProductionManager.ProductionProtocolFlow")]
+    public class ProductionProtocolFlowIntegrationTests : ProductionManagerTestBase
+    {
+        /// <summary>
+        /// Gets or sets the test context for this test run.
+        /// </summary>
+        public required TestContext TestContext { get; set; }
+
+        /// <summary>
+        /// Tests getting production flow for the last 7 days.
+        /// </summary>
+        [TestMethod]
+        public async Task GetProductionFlow_Last7Days_ReturnsData()
+        {
+            // Arrange
+            var productionManagerClient = GetProductionManagerClient();
+            var from = DateTime.UtcNow.AddDays(-7);
+            var to = DateTime.UtcNow;
+
+            // Act
+            var result = await productionManagerClient.GetProductionFlow(from, to);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Trace("Production Flow - Last 7 Days");
+
+            TestContext?.AddResultFile(result.TraceToFile(nameof(GetProductionFlow_Last7Days_ReturnsData)).FullName);
+        }
+
+    }
+}

--- a/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowTests.cs
+++ b/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowTests.cs
@@ -27,10 +27,7 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
         [TestMethod]
         public void ProductionProtocolFlowDetails_SerializeDeserialize_Basic()
         {
-            var flowDetails = new ProductionProtocolFlowDetails
-            {
-                Workstations = new List<ProductionProtocolFlowNode>()
-            };
+            var flowDetails = new ProductionProtocolFlowDetails();
 
             var serialized = JsonConvert.SerializeObject(flowDetails, SerializerSettings.Default);
             var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowDetails>(serialized, SerializerSettings.Default);
@@ -65,13 +62,14 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
                 { ProductionItemType.Part, 80 }
             };
 
-            var node1 = new ProductionProtocolFlowNode(itemTypeSummary1)
+            var node1 = new ProductionProtocolFlowNode
             {
                 InputWorkstation = new Workstation
                 {
                     Id = workstation1Id,
                     Name = "CNC Machine 1",
-                    WorkstationType = WorkstationType.CNC
+                    Type = WorkstationType.CNC,
+                    Group = WorkstationGroup.CNC
                 },
                 OutputWorkstations = new List<ProductionProtocolFlowEdge>
                 {
@@ -81,27 +79,37 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
                         {
                             Id = workstation2Id,
                             Name = "Edgebander 1",
-                            WorkstationType = WorkstationType.Edgebanding
-                        },
-                        ItemTypeSummary = edgeItemTypeSummary
+                            Type = WorkstationType.Edgebanding,
+                            Group = WorkstationGroup.Edgebanding
+                        }
                     }
                 }
             };
 
-            var node2 = new ProductionProtocolFlowNode(itemTypeSummary2)
+            // Populate ItemTypeSummary for node1
+            node1.ItemTypeSummary[ProductionItemType.Part] = 150;
+            node1.ItemTypeSummary[ProductionItemType.AssemblyGroup] = 25;
+
+            // Populate ItemTypeSummary for the edge
+            node1.OutputWorkstations.First().ItemTypeSummary[ProductionItemType.Part] = 80;
+
+            var node2 = new ProductionProtocolFlowNode
             {
                 InputWorkstation = new Workstation
                 {
                     Id = workstation2Id,
                     Name = "Edgebander 1",
-                    WorkstationType = WorkstationType.Edgebanding
+                    Type = WorkstationType.Edgebanding,
+                    Group = WorkstationGroup.Edgebanding
                 }
             };
 
-            var flowDetails = new ProductionProtocolFlowDetails
-            {
-                Workstations = new List<ProductionProtocolFlowNode> { node1, node2 }
-            };
+            // Populate ItemTypeSummary for node2
+            node2.ItemTypeSummary[ProductionItemType.Part] = 100;
+
+            var flowDetails = new ProductionProtocolFlowDetails();
+            ((List<ProductionProtocolFlowNode>)flowDetails.Workstations).Add(node1);
+            ((List<ProductionProtocolFlowNode>)flowDetails.Workstations).Add(node2);
 
             flowDetails.Trace();
 
@@ -116,6 +124,8 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
             deserializedNode1.InputWorkstation.ShouldNotBeNull();
             deserializedNode1.InputWorkstation.Id.ShouldBe(workstation1Id);
             deserializedNode1.InputWorkstation.Name.ShouldBe("CNC Machine 1");
+            deserializedNode1.InputWorkstation.Type.ShouldBe(WorkstationType.CNC);
+            deserializedNode1.InputWorkstation.Group.ShouldBe(WorkstationGroup.CNC);
             deserializedNode1.ItemTypeSummary.ShouldNotBeNull();
             deserializedNode1.ItemTypeSummary[ProductionItemType.Part].ShouldBe(150);
             deserializedNode1.ItemTypeSummary[ProductionItemType.AssemblyGroup].ShouldBe(25);
@@ -125,6 +135,8 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
             var deserializedEdge = deserializedNode1.OutputWorkstations.First();
             deserializedEdge.OutputWorkstation.ShouldNotBeNull();
             deserializedEdge.OutputWorkstation.Id.ShouldBe(workstation2Id);
+            deserializedEdge.OutputWorkstation.Type.ShouldBe(WorkstationType.Edgebanding);
+            deserializedEdge.OutputWorkstation.Group.ShouldBe(WorkstationGroup.Edgebanding);
             deserializedEdge.ItemTypeSummary.ShouldNotBeNull();
             deserializedEdge.ItemTypeSummary[ProductionItemType.Part].ShouldBe(80);
         }
@@ -139,12 +151,8 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
         [TestMethod]
         public void ProductionProtocolFlowNode_SerializeDeserialize_Basic()
         {
-            var itemTypeSummary = new Dictionary<ProductionItemType, int>
-            {
-                { ProductionItemType.Part, 100 }
-            };
-
-            var node = new ProductionProtocolFlowNode(itemTypeSummary);
+            var node = new ProductionProtocolFlowNode();
+            node.ItemTypeSummary[ProductionItemType.Part] = 100;
 
             var serialized = JsonConvert.SerializeObject(node, SerializerSettings.Default);
             var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowNode>(serialized, SerializerSettings.Default);
@@ -161,22 +169,22 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
         public void ProductionProtocolFlowNode_SerializeDeserialize_AllProperties()
         {
             var workstationId = Guid.NewGuid();
-            var itemTypeSummary = new Dictionary<ProductionItemType, int>
-            {
-                { ProductionItemType.Part, 200 },
-                { ProductionItemType.AssemblyGroup, 50 }
-            };
 
-            var node = new ProductionProtocolFlowNode(itemTypeSummary)
+            var node = new ProductionProtocolFlowNode
             {
                 InputWorkstation = new Workstation
                 {
                     Id = workstationId,
                     Name = "Test Workstation",
-                    WorkstationType = WorkstationType.CNC
+                    Type = WorkstationType.CNC,
+                    Group = WorkstationGroup.CNC
                 },
                 OutputWorkstations = new List<ProductionProtocolFlowEdge>()
             };
+
+            // Populate ItemTypeSummary
+            node.ItemTypeSummary[ProductionItemType.Part] = 200;
+            node.ItemTypeSummary[ProductionItemType.AssemblyGroup] = 50;
 
             node.Trace();
 
@@ -187,9 +195,12 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
             deserialized.InputWorkstation.ShouldNotBeNull();
             deserialized.InputWorkstation.Id.ShouldBe(workstationId);
             deserialized.InputWorkstation.Name.ShouldBe("Test Workstation");
-            deserialized.InputWorkstation.WorkstationType.ShouldBe(WorkstationType.CNC);
+            deserialized.InputWorkstation.Type.ShouldBe(WorkstationType.CNC);
+            deserialized.InputWorkstation.Group.ShouldBe(WorkstationGroup.CNC);
             deserialized.ItemTypeSummary.ShouldNotBeNull();
             deserialized.ItemTypeSummary.Count.ShouldBe(2);
+            deserialized.ItemTypeSummary[ProductionItemType.Part].ShouldBe(200);
+            deserialized.ItemTypeSummary[ProductionItemType.AssemblyGroup].ShouldBe(50);
             deserialized.OutputWorkstations.ShouldNotBeNull();
             deserialized.OutputWorkstations.ShouldBeEmpty();
         }
@@ -219,11 +230,6 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
         public void ProductionProtocolFlowEdge_SerializeDeserialize_AllProperties()
         {
             var workstationId = Guid.NewGuid();
-            var itemTypeSummary = new Dictionary<ProductionItemType, int>
-            {
-                { ProductionItemType.Part, 75 },
-                { ProductionItemType.AssemblyGroup, 15 }
-            };
 
             var edge = new ProductionProtocolFlowEdge
             {
@@ -231,10 +237,14 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
                 {
                     Id = workstationId,
                     Name = "Output Workstation",
-                    WorkstationType = WorkstationType.Edgebanding
-                },
-                ItemTypeSummary = itemTypeSummary
+                    Type = WorkstationType.Edgebanding,
+                    Group = WorkstationGroup.Edgebanding
+                }
             };
+
+            // Populate ItemTypeSummary
+            edge.ItemTypeSummary[ProductionItemType.Part] = 75;
+            edge.ItemTypeSummary[ProductionItemType.AssemblyGroup] = 15;
 
             edge.Trace();
 
@@ -245,7 +255,8 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
             deserialized.OutputWorkstation.ShouldNotBeNull();
             deserialized.OutputWorkstation.Id.ShouldBe(workstationId);
             deserialized.OutputWorkstation.Name.ShouldBe("Output Workstation");
-            deserialized.OutputWorkstation.WorkstationType.ShouldBe(WorkstationType.Edgebanding);
+            deserialized.OutputWorkstation.Type.ShouldBe(WorkstationType.Edgebanding);
+            deserialized.OutputWorkstation.Group.ShouldBe(WorkstationGroup.Edgebanding);
             deserialized.ItemTypeSummary.ShouldNotBeNull();
             deserialized.ItemTypeSummary.Count.ShouldBe(2);
             deserialized.ItemTypeSummary[ProductionItemType.Part].ShouldBe(75);
@@ -258,16 +269,11 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
         [TestMethod]
         public void ProductionProtocolFlowEdge_SerializeDeserialize_MultipleItemTypes()
         {
-            var itemTypeSummary = new Dictionary<ProductionItemType, int>
-            {
-                { ProductionItemType.Part, 100 },
-                { ProductionItemType.AssemblyGroup, 20 },
-            };
+            var edge = new ProductionProtocolFlowEdge();
 
-            var edge = new ProductionProtocolFlowEdge
-            {
-                ItemTypeSummary = itemTypeSummary
-            };
+            // Populate ItemTypeSummary
+            edge.ItemTypeSummary[ProductionItemType.Part] = 100;
+            edge.ItemTypeSummary[ProductionItemType.AssemblyGroup] = 20;
 
             var serialized = JsonConvert.SerializeObject(edge, SerializerSettings.Default);
             var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowEdge>(serialized, SerializerSettings.Default);

--- a/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowTests.cs
+++ b/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowTests.cs
@@ -135,6 +135,7 @@ namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
             var deserializedEdge = deserializedNode1.OutputWorkstations.First();
             deserializedEdge.OutputWorkstation.ShouldNotBeNull();
             deserializedEdge.OutputWorkstation.Id.ShouldBe(workstation2Id);
+            deserializedEdge.OutputWorkstation.Name.ShouldBe("Edgebander 1");
             deserializedEdge.OutputWorkstation.Type.ShouldBe(WorkstationType.Edgebanding);
             deserializedEdge.OutputWorkstation.Group.ShouldBe(WorkstationGroup.Edgebanding);
             deserializedEdge.ItemTypeSummary.ShouldNotBeNull();

--- a/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowTests.cs
+++ b/Applications/ProductionManager/Tests/ProductionProtocolFlow/ProductionProtocolFlowTests.cs
@@ -1,0 +1,284 @@
+using HomagConnect.Base.Contracts;
+using HomagConnect.Base.Contracts.Enumerations;
+using HomagConnect.Base.Extensions;
+using HomagConnect.ProductionManager.Contracts.OrderProgress;
+using HomagConnect.ProductionManager.Contracts.ProductionItems;
+using HomagConnect.ProductionManager.Contracts.ProductionProtocolFlow;
+
+using Newtonsoft.Json;
+
+using Shouldly;
+
+namespace HomagConnect.ProductionManager.Tests.ProductionProtocolFlow
+{
+    /// <summary>
+    /// Tests for Production Protocol Flow functionality.
+    /// </summary>
+    [TestClass]
+    [TestCategory("ProductionManager")]
+    [TestCategory("ProductionManager.ProductionProtocolFlow")]
+    public class ProductionProtocolFlowTests
+    {
+        #region ProductionProtocolFlowDetails Serialization Tests
+
+        /// <summary>
+        /// Tests basic serialization and deserialization of ProductionProtocolFlowDetails
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowDetails_SerializeDeserialize_Basic()
+        {
+            var flowDetails = new ProductionProtocolFlowDetails
+            {
+                Workstations = new List<ProductionProtocolFlowNode>()
+            };
+
+            var serialized = JsonConvert.SerializeObject(flowDetails, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowDetails>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+            deserialized.Workstations.ShouldNotBeNull();
+            deserialized.Workstations.ShouldBeEmpty();
+        }
+
+        /// <summary>
+        /// Tests serialization with complete data structure
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowDetails_SerializeDeserialize_Complete()
+        {
+            var workstation1Id = Guid.NewGuid();
+            var workstation2Id = Guid.NewGuid();
+
+            var itemTypeSummary1 = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 150 },
+                { ProductionItemType.AssemblyGroup, 25 }
+            };
+
+            var itemTypeSummary2 = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 100 }
+            };
+
+            var edgeItemTypeSummary = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 80 }
+            };
+
+            var node1 = new ProductionProtocolFlowNode(itemTypeSummary1)
+            {
+                InputWorkstation = new Workstation
+                {
+                    Id = workstation1Id,
+                    Name = "CNC Machine 1",
+                    WorkstationType = WorkstationType.CNC
+                },
+                OutputWorkstations = new List<ProductionProtocolFlowEdge>
+                {
+                    new ProductionProtocolFlowEdge
+                    {
+                        OutputWorkstation = new Workstation
+                        {
+                            Id = workstation2Id,
+                            Name = "Edgebander 1",
+                            WorkstationType = WorkstationType.Edgebanding
+                        },
+                        ItemTypeSummary = edgeItemTypeSummary
+                    }
+                }
+            };
+
+            var node2 = new ProductionProtocolFlowNode(itemTypeSummary2)
+            {
+                InputWorkstation = new Workstation
+                {
+                    Id = workstation2Id,
+                    Name = "Edgebander 1",
+                    WorkstationType = WorkstationType.Edgebanding
+                }
+            };
+
+            var flowDetails = new ProductionProtocolFlowDetails
+            {
+                Workstations = new List<ProductionProtocolFlowNode> { node1, node2 }
+            };
+
+            flowDetails.Trace();
+
+            var serialized = JsonConvert.SerializeObject(flowDetails, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowDetails>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+            deserialized.Workstations.ShouldNotBeNull();
+            deserialized.Workstations.Count().ShouldBe(2);
+
+            var deserializedNode1 = deserialized.Workstations.First();
+            deserializedNode1.InputWorkstation.ShouldNotBeNull();
+            deserializedNode1.InputWorkstation.Id.ShouldBe(workstation1Id);
+            deserializedNode1.InputWorkstation.Name.ShouldBe("CNC Machine 1");
+            deserializedNode1.ItemTypeSummary.ShouldNotBeNull();
+            deserializedNode1.ItemTypeSummary[ProductionItemType.Part].ShouldBe(150);
+            deserializedNode1.ItemTypeSummary[ProductionItemType.AssemblyGroup].ShouldBe(25);
+            deserializedNode1.OutputWorkstations.ShouldNotBeNull();
+            deserializedNode1.OutputWorkstations.Count().ShouldBe(1);
+
+            var deserializedEdge = deserializedNode1.OutputWorkstations.First();
+            deserializedEdge.OutputWorkstation.ShouldNotBeNull();
+            deserializedEdge.OutputWorkstation.Id.ShouldBe(workstation2Id);
+            deserializedEdge.ItemTypeSummary.ShouldNotBeNull();
+            deserializedEdge.ItemTypeSummary[ProductionItemType.Part].ShouldBe(80);
+        }
+
+        #endregion
+
+        #region ProductionProtocolFlowNode Serialization Tests
+
+        /// <summary>
+        /// Tests basic serialization and deserialization of ProductionProtocolFlowNode
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowNode_SerializeDeserialize_Basic()
+        {
+            var itemTypeSummary = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 100 }
+            };
+
+            var node = new ProductionProtocolFlowNode(itemTypeSummary);
+
+            var serialized = JsonConvert.SerializeObject(node, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowNode>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+            deserialized.ItemTypeSummary.ShouldNotBeNull();
+            deserialized.ItemTypeSummary[ProductionItemType.Part].ShouldBe(100);
+        }
+
+        /// <summary>
+        /// Tests serialization with all properties set
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowNode_SerializeDeserialize_AllProperties()
+        {
+            var workstationId = Guid.NewGuid();
+            var itemTypeSummary = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 200 },
+                { ProductionItemType.AssemblyGroup, 50 }
+            };
+
+            var node = new ProductionProtocolFlowNode(itemTypeSummary)
+            {
+                InputWorkstation = new Workstation
+                {
+                    Id = workstationId,
+                    Name = "Test Workstation",
+                    WorkstationType = WorkstationType.CNC
+                },
+                OutputWorkstations = new List<ProductionProtocolFlowEdge>()
+            };
+
+            node.Trace();
+
+            var serialized = JsonConvert.SerializeObject(node, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowNode>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+            deserialized.InputWorkstation.ShouldNotBeNull();
+            deserialized.InputWorkstation.Id.ShouldBe(workstationId);
+            deserialized.InputWorkstation.Name.ShouldBe("Test Workstation");
+            deserialized.InputWorkstation.WorkstationType.ShouldBe(WorkstationType.CNC);
+            deserialized.ItemTypeSummary.ShouldNotBeNull();
+            deserialized.ItemTypeSummary.Count.ShouldBe(2);
+            deserialized.OutputWorkstations.ShouldNotBeNull();
+            deserialized.OutputWorkstations.ShouldBeEmpty();
+        }
+
+        #endregion
+
+        #region ProductionProtocolFlowEdge Serialization Tests
+
+        /// <summary>
+        /// Tests basic serialization and deserialization of ProductionProtocolFlowEdge
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowEdge_SerializeDeserialize_Basic()
+        {
+            var edge = new ProductionProtocolFlowEdge();
+
+            var serialized = JsonConvert.SerializeObject(edge, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowEdge>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Tests serialization with all properties set
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowEdge_SerializeDeserialize_AllProperties()
+        {
+            var workstationId = Guid.NewGuid();
+            var itemTypeSummary = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 75 },
+                { ProductionItemType.AssemblyGroup, 15 }
+            };
+
+            var edge = new ProductionProtocolFlowEdge
+            {
+                OutputWorkstation = new Workstation
+                {
+                    Id = workstationId,
+                    Name = "Output Workstation",
+                    WorkstationType = WorkstationType.Edgebanding
+                },
+                ItemTypeSummary = itemTypeSummary
+            };
+
+            edge.Trace();
+
+            var serialized = JsonConvert.SerializeObject(edge, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowEdge>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+            deserialized.OutputWorkstation.ShouldNotBeNull();
+            deserialized.OutputWorkstation.Id.ShouldBe(workstationId);
+            deserialized.OutputWorkstation.Name.ShouldBe("Output Workstation");
+            deserialized.OutputWorkstation.WorkstationType.ShouldBe(WorkstationType.Edgebanding);
+            deserialized.ItemTypeSummary.ShouldNotBeNull();
+            deserialized.ItemTypeSummary.Count.ShouldBe(2);
+            deserialized.ItemTypeSummary[ProductionItemType.Part].ShouldBe(75);
+            deserialized.ItemTypeSummary[ProductionItemType.AssemblyGroup].ShouldBe(15);
+        }
+
+        /// <summary>
+        /// Tests serialization with multiple item types
+        /// </summary>
+        [TestMethod]
+        public void ProductionProtocolFlowEdge_SerializeDeserialize_MultipleItemTypes()
+        {
+            var itemTypeSummary = new Dictionary<ProductionItemType, int>
+            {
+                { ProductionItemType.Part, 100 },
+                { ProductionItemType.AssemblyGroup, 20 },
+            };
+
+            var edge = new ProductionProtocolFlowEdge
+            {
+                ItemTypeSummary = itemTypeSummary
+            };
+
+            var serialized = JsonConvert.SerializeObject(edge, SerializerSettings.Default);
+            var deserialized = JsonConvert.DeserializeObject<ProductionProtocolFlowEdge>(serialized, SerializerSettings.Default);
+
+            deserialized.ShouldNotBeNull();
+            deserialized.ItemTypeSummary.ShouldNotBeNull();
+            deserialized.ItemTypeSummary.Count.ShouldBe(2);
+            deserialized.ItemTypeSummary[ProductionItemType.Part].ShouldBe(100);
+            deserialized.ItemTypeSummary[ProductionItemType.AssemblyGroup].ShouldBe(20);
+        }
+
+        #endregion
+    }
+}

--- a/Base/HomagConnect.Base.Contracts/HomagConnect.Base.Contracts.csproj
+++ b/Base/HomagConnect.Base.Contracts/HomagConnect.Base.Contracts.csproj
@@ -65,6 +65,11 @@
 	    <AutoGen>True</AutoGen>
 	    <DependentUpon>GrainDisplayNames.resx</DependentUpon>
 	  </Compile>
+	  <Compile Update="WorkstationPropertyDisplayNames.Designer.cs">
+	    <DependentUpon>WorkstationPropertyDisplayNames.resx</DependentUpon>
+	    <DesignTime>True</DesignTime>
+	    <AutoGen>True</AutoGen>
+	  </Compile>
 	</ItemGroup>
 	<ItemGroup>
 	  <EmbeddedResource Update="AdditionalData\AdditionalDataPreviewSizeDisplayNames.resx">
@@ -105,6 +110,10 @@
 	  <EmbeddedResource Update="Enumerations\GrainDisplayNames.resx">
 	    <Generator>PublicResXFileCodeGenerator</Generator>
 	    <LastGenOutput>GrainDisplayNames.Designer.cs</LastGenOutput>
+	  </EmbeddedResource>
+	  <EmbeddedResource Update="WorkstationPropertyDisplayNames.resx">
+	    <LastGenOutput>WorkstationPropertyDisplayNames.Designer.cs</LastGenOutput>
+	    <Generator>PublicResXFileCodeGenerator</Generator>
 	  </EmbeddedResource>
 	</ItemGroup>
 

--- a/Base/HomagConnect.Base.Contracts/Workstation.cs
+++ b/Base/HomagConnect.Base.Contracts/Workstation.cs
@@ -30,7 +30,11 @@ public class Workstation
     /// </summary>
     /// <example>Cutting</example>
     [Obsolete("This property is obsolete. Use the new Type property instead.", true)]
-    public WorkstationType WorkstationType { get; set; }
+    public WorkstationType WorkstationType 
+    {
+        get { return Type; }
+        set { Type = value; }
+    }
 
     /// <summary>
     /// Gets or sets the workstation type.

--- a/Base/HomagConnect.Base.Contracts/Workstation.cs
+++ b/Base/HomagConnect.Base.Contracts/Workstation.cs
@@ -1,4 +1,5 @@
 ﻿using HomagConnect.Base.Contracts.Enumerations;
+using System.ComponentModel.DataAnnotations;
 
 namespace HomagConnect.Base.Contracts;
 
@@ -20,6 +21,7 @@ public class Workstation
     /// Gets or sets the display name of the workstation.
     /// </summary>
     /// <example>productionAssist Cutting</example>
+    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(Name))]
     public string Name { get; set; }
 
     /// <summary>
@@ -27,5 +29,22 @@ public class Workstation
     /// Example values include <c>Cutting</c>, <c>Nesting</c>, <c>Storage</c>, <c>CNC</c>, and <c>Assembly</c>.
     /// </summary>
     /// <example>Cutting</example>
+    [Obsolete("This property is obsolete. Use the new Type property instead.", true)]
     public WorkstationType WorkstationType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the workstation type.
+    /// Example values include <c>Cutting</c>, <c>Nesting</c>, <c>Storage</c>, <c>CNC</c>, and <c>Assembly</c>.
+    /// </summary>
+    /// <example>Cutting</example>
+    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(Type))]
+    public WorkstationType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the workstation group.
+    /// Example values include <c>Dividing</c>, <c>Edgebanding</c>, <c>CNC</c>, and <c>Assembly</c>.
+    /// </summary>
+    /// <example>Dividing</example>
+    [Display(ResourceType = typeof(WorkstationPropertyDisplayNames), Name = nameof(Group))]
+    public WorkstationGroup Group { get; set; }
 }

--- a/Base/HomagConnect.Base.Contracts/WorkstationPropertyDisplayNames.Designer.cs
+++ b/Base/HomagConnect.Base.Contracts/WorkstationPropertyDisplayNames.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace HomagConnect.ProductionAssist.Contracts {
+namespace HomagConnect.Base.Contracts {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace HomagConnect.ProductionAssist.Contracts {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("HomagConnect.ProductionAssist.Contracts.WorkstationPropertyDisplayNames", typeof(WorkstationPropertyDisplayNames).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("HomagConnect.Base.Contracts.WorkstationPropertyDisplayNames", typeof(WorkstationPropertyDisplayNames).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -61,11 +61,38 @@ namespace HomagConnect.ProductionAssist.Contracts {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to zugewiesene Tapio Maschine.
+        ///   Looks up a localized string similar to Gruppe.
         /// </summary>
-        public static string AssignedTapioMachineId {
+        public static string Group {
             get {
-                return ResourceManager.GetString("AssignedTapioMachineId", resourceCulture);
+                return ResourceManager.GetString("Group", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ID.
+        /// </summary>
+        public static string Id {
+            get {
+                return ResourceManager.GetString("Id", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Beschreibung.
+        /// </summary>
+        public static string Name {
+            get {
+                return ResourceManager.GetString("Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Arbeitsplatztyp.
+        /// </summary>
+        public static string Type {
+            get {
+                return ResourceManager.GetString("Type", resourceCulture);
             }
         }
     }

--- a/Base/HomagConnect.Base.Contracts/WorkstationPropertyDisplayNames.resx
+++ b/Base/HomagConnect.Base.Contracts/WorkstationPropertyDisplayNames.resx
@@ -117,8 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AssignedTapioMachineId" xml:space="preserve">
-    <value>zugewiesene Tapio Maschine</value>
-    <comment>zugewiesene Tapio Maschine</comment>
+  <data name="Name" xml:space="preserve">
+    <value>Beschreibung</value>
+    <comment>Beschreibung</comment>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Gruppe</value>
+    <comment>Gruppe</comment>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>ID</value>
+    <comment>Id</comment>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Arbeitsplatztyp</value>
   </data>
 </root>


### PR DESCRIPTION
refactor workstation classes in base and in PA (for the events)
Base class gets additionally group
PA-Class derives from base
Naming is aligned. No "WorkstationType" in workstation class. Just name it Type. Same for Group
resource for localization are split