### PR TITLE
feat: Refactor texture API to use TextureFilter for queries

### DIFF
--- a/Applications/MaterialManager/Client/MaterialManagerClientTextures.cs
+++ b/Applications/MaterialManager/Client/MaterialManagerClientTextures.cs
@@ -38,50 +38,41 @@ public class MaterialManagerClientTextures : ClientBase, IMaterialManagerClientT
     }
 
     /// <inheritdoc />
-    public async Task<PagedTextureResult> GetTextures(int pageSize = 100, string? continuationToken = null)
-    {
-        var url = $"{_BaseRoute}?pageSize={pageSize}";
-        if (!string.IsNullOrWhiteSpace(continuationToken))
-        {
-            url += $"&continuationToken={Uri.EscapeDataString(continuationToken)}";
-        }
-
-        var response = await RequestObject<PagedTextureResult>(new Uri(url, UriKind.Relative));
-        return response ?? new PagedTextureResult();
-    }
+    [Obsolete("Use GetTextures(TextureFilter, ...) instead.")]
+    public Task<PagedTextureResult> GetTextures(int pageSize = 100, string? continuationToken = null)
+        => GetTextures(new TextureFilter(), pageSize, continuationToken);
 
     /// <inheritdoc />
-    public async Task<PagedTextureResult> GetTextures(string? catalog, int pageSize = 100, string? continuationToken = null)
-    {
-        var url = $"{_BaseRoute}?pageSize={pageSize}";
-
-        if (!string.IsNullOrWhiteSpace(catalog))
-        {
-            url += $"&catalog={Uri.EscapeDataString(catalog)}";
-        }
-
-        if (!string.IsNullOrWhiteSpace(continuationToken))
-        {
-            url += $"&continuationToken={Uri.EscapeDataString(continuationToken)}";
-        }
-
-        var response = await RequestObject<PagedTextureResult>(new Uri(url, UriKind.Relative));
-        return response ?? new PagedTextureResult();
-    }
+    [Obsolete("Use GetTextures(TextureFilter, ...) instead.")]
+    public Task<PagedTextureResult> GetTextures(string? catalog, int pageSize = 100, string? continuationToken = null)
+        => GetTextures(new TextureFilter { Catalog = catalog }, pageSize, continuationToken);
 
     /// <inheritdoc />
-    public async Task<PagedTextureResult> GetTextures(string? catalog, string? decorCode, int pageSize = 100, string? continuationToken = null)
+    [Obsolete("Use GetTextures(TextureFilter, ...) instead.")]
+    public Task<PagedTextureResult> GetTextures(string? catalog, string? decorCode, int pageSize = 100, string? continuationToken = null)
+        => GetTextures(new TextureFilter { Catalog = catalog, DecorCode = decorCode }, pageSize, continuationToken);
+
+    /// <inheritdoc />
+    public async Task<PagedTextureResult> GetTextures(TextureFilter? filter = null, int pageSize = 100, string? continuationToken = null)
     {
         var url = $"{_BaseRoute}?pageSize={pageSize}";
 
-        if (!string.IsNullOrWhiteSpace(catalog))
+        if (filter is not null)
         {
-            url += $"&catalog={Uri.EscapeDataString(catalog)}";
-        }
+            if (!string.IsNullOrWhiteSpace(filter.Catalog))
+            {
+                url += $"&catalog={Uri.EscapeDataString(filter.Catalog)}";
+            }
 
-        if (!string.IsNullOrWhiteSpace(decorCode))
-        {
-            url += $"&decorCode={Uri.EscapeDataString(decorCode)}";
+            if (!string.IsNullOrWhiteSpace(filter.DecorCode))
+            {
+                url += $"&decorCode={Uri.EscapeDataString(filter.DecorCode)}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(filter.Embossing))
+            {
+                url += $"&embossing={Uri.EscapeDataString(filter.Embossing)}";
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(continuationToken))

--- a/Applications/MaterialManager/Contracts/Extension/MaterialManagerClientExtensions.cs
+++ b/Applications/MaterialManager/Contracts/Extension/MaterialManagerClientExtensions.cs
@@ -64,7 +64,7 @@ namespace HomagConnect.MaterialManager.Contracts.Extension
             return AsyncPaging.GetAllByContinuationToken<Texture>(
                 async continuationToken =>
                 {
-                    var result = await materialManagerClientTextures.GetTextures(DefaultContinuationTokenPageSize, continuationToken);
+                    var result = await materialManagerClientTextures.GetTextures(filter: null, pageSize: DefaultContinuationTokenPageSize, continuationToken: continuationToken);
                     return new AsyncPaging.ContinuationTokenPage<Texture>(result.Textures, result.ContinuationToken);
                 },
                 cancellationToken);

--- a/Applications/MaterialManager/Contracts/Surfaces/Textures/IMaterialManagerClientSurfaceTextures.cs
+++ b/Applications/MaterialManager/Contracts/Surfaces/Textures/IMaterialManagerClientSurfaceTextures.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 using HomagConnect.MaterialManager.Contracts.Surfaces.Textures.Roomle;
 
@@ -31,6 +32,7 @@ public interface IMaterialManagerClientTextures
     /// <param name="pageSize">The maximum number of items to return. Defaults to 100.</param>
     /// <param name="continuationToken">Optional continuation token for paged traversal.</param>
     /// <returns>A paged result containing textures and optional continuation token for the next page.</returns>
+    [Obsolete("Use GetTextures(TextureFilter, ...) instead.")]
     Task<PagedTextureResult> GetTextures(int pageSize = 100, string? continuationToken = null);
 
     /// <summary>
@@ -40,6 +42,7 @@ public interface IMaterialManagerClientTextures
     /// <param name="pageSize">The maximum number of items to return. Defaults to 100.</param>
     /// <param name="continuationToken">Optional continuation token for paged traversal.</param>
     /// <returns>A paged result containing textures and optional continuation token for the next page.</returns>
+    [Obsolete("Use GetTextures(TextureFilter, ...) instead.")]
     Task<PagedTextureResult> GetTextures(string? catalog, int pageSize = 100, string? continuationToken = null);
 
     /// <summary>
@@ -50,7 +53,20 @@ public interface IMaterialManagerClientTextures
     /// <param name="pageSize">The maximum number of items to return. Defaults to 100.</param>
     /// <param name="continuationToken">Optional continuation token for paged traversal.</param>
     /// <returns>A paged result containing textures and optional continuation token for the next page.</returns>
+    [Obsolete("Use GetTextures(TextureFilter, ...) instead.")]
     Task<PagedTextureResult> GetTextures(string? catalog, string? decorCode, int pageSize = 100, string? continuationToken = null);
+
+    /// <summary>
+    /// Gets a paged list of textures with optional filtering using continuation token pagination.
+    /// </summary>
+    /// <param name="filter">
+    /// Optional filter criteria. Pass <see langword="null" /> or an empty <see cref="TextureFilter" /> to return all textures.
+    /// Any combination of filter properties is supported.
+    /// </param>
+    /// <param name="pageSize">The maximum number of items to return. Defaults to 100.</param>
+    /// <param name="continuationToken">Optional continuation token for paged traversal.</param>
+    /// <returns>A paged result containing textures and optional continuation token for the next page.</returns>
+    Task<PagedTextureResult> GetTextures(TextureFilter? filter = null, int pageSize = 100, string? continuationToken = null);
 
     /// <summary>
     /// Imports or updates a single Roomle material definition with optional file references.

--- a/Applications/MaterialManager/Contracts/Surfaces/Textures/TextureFilter.cs
+++ b/Applications/MaterialManager/Contracts/Surfaces/Textures/TextureFilter.cs
@@ -1,0 +1,17 @@
+﻿namespace HomagConnect.MaterialManager.Contracts.Surfaces.Textures;
+
+/// <summary>
+/// Optional filter criteria for texture queries.
+/// All properties are optional; only non-null values are applied.
+/// </summary>
+public class TextureFilter
+{
+    /// <summary>Gets or sets the catalog to filter by.</summary>
+    public string? Catalog { get; set; }
+
+    /// <summary>Gets or sets the decor code to filter by.</summary>
+    public string? DecorCode { get; set; }
+
+    /// <summary>Gets or sets the embossing to filter by.</summary>
+    public string? Embossing { get; set; }
+}

--- a/Applications/MaterialManager/Samples/Surfaces/Textures/Readme.md
+++ b/Applications/MaterialManager/Samples/Surfaces/Textures/Readme.md
@@ -26,7 +26,7 @@ Console.WriteLine($"Name: {texture.Name}");
 
 ## GetTextures
 
-Retrieve textures with pagination support using continuation tokens.
+Retrieve textures with pagination support using continuation tokens. Use a `TextureFilter` to narrow results by `Catalog`, `DecorCode`, and/or `Embossing`; pass `null` or an empty `TextureFilter` to return all textures.
 
 **Example:**
 
@@ -60,11 +60,9 @@ Retrieve textures filtered by catalog.
 ```csharp
 var client = new MaterialManagerClientTextures(subscriptionId, authorizationKey);
 
-var catalog = "hpl";
+var result = await client.GetTextures(new TextureFilter { Catalog = "hpl" }, pageSize: 10);
 
-var result = await client.GetTextures(catalog: catalog, pageSize: 10);
-
-Console.WriteLine($"Retrieved {result.Textures.Count} textures from catalog '{catalog}'");
+Console.WriteLine($"Retrieved {result.Textures.Count} textures from catalog 'hpl'");
 
 foreach (var texture in result.Textures)
 {
@@ -81,16 +79,32 @@ Retrieve textures filtered by catalog and decor code.
 ```csharp
 var client = new MaterialManagerClientTextures(subscriptionId, authorizationKey);
 
-var catalog = "hpl";
-var decorCode = "f274_9";
-
-var result = await client.GetTextures(catalog: catalog, decorCode: decorCode, pageSize: 10);
+var result = await client.GetTextures(new TextureFilter { Catalog = "hpl", DecorCode = "f274_9" }, pageSize: 10);
 
 Console.WriteLine($"Retrieved {result.Textures.Count} textures");
 
 foreach (var texture in result.Textures)
 {
     Console.WriteLine($"Embossing: {texture.Embossing}");
+}
+```
+
+## GetTextures by Catalog, DecorCode and Embossing
+
+Retrieve textures filtered by catalog, decor code and embossing.
+
+**Example:**
+
+```csharp
+var client = new MaterialManagerClientTextures(subscriptionId, authorizationKey);
+
+var result = await client.GetTextures(new TextureFilter { Catalog = "hpl", DecorCode = "f274_9", Embossing = "st7" }, pageSize: 10);
+
+Console.WriteLine($"Retrieved {result.Textures.Count} textures");
+
+foreach (var texture in result.Textures)
+{
+    Console.WriteLine($"- {texture.Id} ({texture.Name})");
 }
 ```
 

--- a/Applications/MaterialManager/Samples/Surfaces/Textures/TextureSamples.cs
+++ b/Applications/MaterialManager/Samples/Surfaces/Textures/TextureSamples.cs
@@ -31,7 +31,7 @@ public class TextureSamples
     /// </summary>
     public static async Task Textures_GetTextures(IMaterialManagerClientTextures textureClient)
     {
-        var result = await textureClient.GetTextures(pageSize: 10);
+        var result = await textureClient.GetTextures(new TextureFilter(), pageSize: 10);
 
         foreach (var texture in result.Textures)
         {
@@ -41,7 +41,7 @@ public class TextureSamples
         // Use continuation token for next page if available
         if (!string.IsNullOrEmpty(result.ContinuationToken))
         {
-            var nextResult = await textureClient.GetTextures(pageSize: 10, continuationToken: result.ContinuationToken);
+            var nextResult = await textureClient.GetTextures(new TextureFilter(), pageSize: 10, continuationToken: result.ContinuationToken);
         }
     }
 
@@ -50,7 +50,7 @@ public class TextureSamples
     /// </summary>
     public static async Task Textures_GetTexturesByCatalog(IMaterialManagerClientTextures textureClient, string catalog)
     {
-        var result = await textureClient.GetTextures(catalog: catalog, pageSize: 10);
+        var result = await textureClient.GetTextures(new TextureFilter { Catalog = catalog }, pageSize: 10);
 
         foreach (var texture in result.Textures)
         {
@@ -66,7 +66,7 @@ public class TextureSamples
         string catalog,
         string decorCode)
     {
-        var result = await textureClient.GetTextures(catalog: catalog, decorCode: decorCode, pageSize: 10);
+        var result = await textureClient.GetTextures(new TextureFilter { Catalog = catalog, DecorCode = decorCode }, pageSize: 10);
 
         foreach (var texture in result.Textures)
         {

--- a/Applications/MaterialManager/Tests/Surfaces/Textures/TextureTests.cs
+++ b/Applications/MaterialManager/Tests/Surfaces/Textures/TextureTests.cs
@@ -204,7 +204,7 @@ public class TextureTests : MaterialManagerTestBase
     public async Task GetTextures_WithDefaults_ReturnsPaginatedResult()
     {
         // Act
-        var result = await _MaterialManagerClientTextures!.GetTextures();
+        var result = await _MaterialManagerClientTextures!.GetTextures(new TextureFilter());
 
         // Assert
         result.ShouldNotBeNull("because paged texture result should be returned");
@@ -222,7 +222,7 @@ public class TextureTests : MaterialManagerTestBase
         const int pageSize = 10;
 
         // Act
-        var result = await _MaterialManagerClientTextures!.GetTextures(pageSize: pageSize);
+        var result = await _MaterialManagerClientTextures!.GetTextures(new TextureFilter(), pageSize: pageSize);
 
         // Assert
         result.ShouldNotBeNull("because paged texture result should be returned");
@@ -241,13 +241,13 @@ public class TextureTests : MaterialManagerTestBase
 
         var stopwatch = Stopwatch.StartNew();
 
-        var firstPageTextures = (await _MaterialManagerClientTextures!.GetTextures(pageSize: pageSize)).Textures;
+        var firstPageTextures = (await _MaterialManagerClientTextures!.GetTextures(new TextureFilter(), pageSize: pageSize)).Textures;
 
         TestContext!.WriteLine($"Time taken to fetch {firstPageTextures.Count} of {pageSize} textures: {stopwatch.Elapsed}");
 
         stopwatch.Restart();
 
-        var allTextures =await _MaterialManagerClientTextures.GetTextures(TestContext.CancellationToken).ToListAsync();
+        var allTextures = await _MaterialManagerClientTextures.GetTextures(TestContext.CancellationToken).ToListAsync();
 
         TestContext.WriteLine($"Time taken to fetch all {allTextures.Count} textures: {stopwatch.Elapsed}");
 
@@ -279,7 +279,7 @@ public class TextureTests : MaterialManagerTestBase
         do
         {
             pageCount++;
-            var result = await _MaterialManagerClientTextures!.GetTextures(pageSize: pageSize, continuationToken: continuationToken);
+            var result = await _MaterialManagerClientTextures!.GetTextures(filter: null, pageSize: pageSize, continuationToken: continuationToken);
 
             result.ShouldNotBeNull("because paged result should be returned");
             result.Textures.ShouldNotBeNull("because textures list should be present");
@@ -310,11 +310,10 @@ public class TextureTests : MaterialManagerTestBase
     public async Task GetTextures_WithCatalogFilter_ReturnsOnlyFilteredCatalog()
     {
         // Arrange
-        // Ensure textures are available
         await EnsureTestTexturesExistAsync();
 
         // Act
-        var result = await _MaterialManagerClientTextures!.GetTextures(catalog: _TestCatalog);
+        var result = await _MaterialManagerClientTextures!.GetTextures(new TextureFilter { Catalog = _TestCatalog });
 
         // Assert
         result.ShouldNotBeNull("because paged result should be returned");
@@ -331,8 +330,11 @@ public class TextureTests : MaterialManagerTestBase
     [TestMethod]
     public async Task GetTextures_WithCatalogAndDecorCodeFilter_ReturnsOnlyFilteredResults()
     {
+        // Arrange
+        await EnsureTestTexturesExistAsync();
+
         // Act
-        var result = await _MaterialManagerClientTextures!.GetTextures(catalog: _TestCatalog, decorCode: _TestCatalogDecor1);
+        var result = await _MaterialManagerClientTextures!.GetTextures(new TextureFilter { Catalog = _TestCatalog, DecorCode = _TestCatalogDecor1 });
 
         // Assert
         result.ShouldNotBeNull("because paged result should be returned");
@@ -342,13 +344,36 @@ public class TextureTests : MaterialManagerTestBase
     }
 
     /// <summary>
+    /// Tests retrieval of textures filtered by catalog, decor code, and embossing.
+    /// </summary>
+    [TestMethod]
+    public async Task GetTextures_WithFullFilter_ReturnsOnlyMatchingTexture()
+    {
+        // Arrange
+        await EnsureTestTexturesExistAsync();
+
+        // Act
+        var result = await _MaterialManagerClientTextures!.GetTextures(
+            new TextureFilter { Catalog = _TestCatalog, DecorCode = _TestCatalogDecor1, Embossing = _TestCatalogEmb1 });
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Textures.ShouldNotBeNull();
+        result.Textures.All(t =>
+            t.Catalog == _TestCatalog &&
+            t.DecorCode == _TestCatalogDecor1 &&
+            t.Embossing == _TestCatalogEmb1
+        ).ShouldBeTrue("because all fields of the filter should be applied");
+    }
+
+    /// <summary>
     /// Tests that null catalog parameter works correctly.
     /// </summary>
     [TestMethod]
     public async Task GetTextures_WithNullCatalog_ReturnsAllTextures()
     {
         // Act
-        var result = await _MaterialManagerClientTextures!.GetTextures(catalog: null);
+        var result = await _MaterialManagerClientTextures!.GetTextures(new TextureFilter { Catalog = null });
 
         // Assert
         result.ShouldNotBeNull("because paged result should be returned");
@@ -362,7 +387,7 @@ public class TextureTests : MaterialManagerTestBase
     public async Task GetTextures_WithNullCatalogAndDecorCode_ReturnsAllTextures()
     {
         // Act
-        var result = await _MaterialManagerClientTextures!.GetTextures(catalog: null, decorCode: null);
+        var result = await _MaterialManagerClientTextures!.GetTextures(new TextureFilter { Catalog = null, DecorCode = null });
 
         // Assert
         result.ShouldNotBeNull("because paged result should be returned");
@@ -376,7 +401,7 @@ public class TextureTests : MaterialManagerTestBase
     public async Task GetTextures_WithZeroPageSize_ThrowsException()
     {
         // Act & Assert
-        var act = async () => await _MaterialManagerClientTextures!.GetTextures(pageSize: 0);
+        var act = async () => await _MaterialManagerClientTextures!.GetTextures(new TextureFilter(), pageSize: 0);
         await Should.ThrowAsync<HttpRequestException>(act,
             "because page size must be greater than 0");
     }
@@ -388,7 +413,7 @@ public class TextureTests : MaterialManagerTestBase
     public async Task GetTextures_WithNegativePageSize_ThrowsException()
     {
         // Act & Assert
-        var act = async () => await _MaterialManagerClientTextures!.GetTextures(pageSize: -5);
+        var act = async () => await _MaterialManagerClientTextures!.GetTextures(new TextureFilter(), pageSize: -5);
         await Should.ThrowAsync<HttpRequestException>(act,
             "because page size must be greater than 0");
     }
@@ -401,7 +426,7 @@ public class TextureTests : MaterialManagerTestBase
     {
         // Act & Assert
         const int excessivePageSize = 1000;
-        var act = async () => await _MaterialManagerClientTextures!.GetTextures(pageSize: excessivePageSize);
+        var act = async () => await _MaterialManagerClientTextures!.GetTextures(new TextureFilter(), pageSize: excessivePageSize);
         await Should.ThrowAsync<HttpRequestException>(act,
             "because page size must not exceed maximum allowed (100)");
     }
@@ -413,7 +438,7 @@ public class TextureTests : MaterialManagerTestBase
     public async Task GetTextures_WithDecorCodeButNoCatalog_ThrowsException()
     {
         // Act & Assert - decor code without catalog should fail on API side
-        var act = async () => await _MaterialManagerClientTextures!.GetTextures(catalog: null, decorCode: "some-decor");
+        var act = async () => await _MaterialManagerClientTextures!.GetTextures(new TextureFilter { Catalog = null, DecorCode = "some-decor" });
         await Should.ThrowAsync<HttpRequestException>(act,
             "because API should reject decor code filter when catalog is not specified");
     }


### PR DESCRIPTION
Replaces multiple GetTextures overloads with a single method accepting a TextureFilter for flexible filtering by catalog, decor code, and embossing. Marks old overloads as obsolete and updates all usages, tests, and documentation to the new API. Adds new test cases and documentation for advanced filtering scenarios.