### PR TITLE
reactivate tests

### DIFF
--- a/Applications/IntelliDivide/Tests/Statistics/StatisticTests.cs
+++ b/Applications/IntelliDivide/Tests/Statistics/StatisticTests.cs
@@ -69,8 +69,7 @@ public class StatisticTests : IntelliDivideTestBase
     public async Task Statistics_GetPartSizesByMaterial_NoException()
     {
         var intelliDivide = GetIntelliDivideClient();
-
-        var materialCodes = new[] { "P2_White_19", "P2_White_8" };
+        var materialCodes = (await intelliDivide.GetBoardTypes(9999)).Select(ma=> ma.BoardCode);
 
         var to = DateTime.Now.AddDays(-1);
         var from = to.AddMonths(-3);
@@ -89,7 +88,7 @@ public class StatisticTests : IntelliDivideTestBase
     {
         var intelliDivide = GetIntelliDivideClient();
 
-        var materialCodes = new[] { "P2_White_19", "P2_White_8" };
+        var materialCodes = (await intelliDivide.GetBoardTypes(9999)).Select(ma => ma.BoardCode);
 
         var statistics = await intelliDivide.GetPartSizesByMaterialStatistics(materialCodes, 90).ToListAsync();
         if (statistics == null || !statistics.Any())

--- a/Applications/ProductionAssist/Tests/Feedback/ProductionAssistFeedbackTests.cs
+++ b/Applications/ProductionAssist/Tests/Feedback/ProductionAssistFeedbackTests.cs
@@ -28,28 +28,5 @@ namespace HomagConnect.ProductionAssist.Tests.Feedback
                 Assert.Inconclusive("Request data from sample might not be correct.");
             }
         }
-
-        [TestMethod]
-        public void FeedbackWorkstation_BackwardCompatibility_Serialization()
-        {
-            var id = Guid.NewGuid();
-            var name = "Saw 01";
-            var oldJson = $@"
-            {{
-                ""Id"": ""{id}"",
-                ""DisplayName"": ""{name}""
-            }}";
-
-            // deserialize with new class
-            var workstation = JsonConvert.DeserializeObject<FeedbackWorkstation>(oldJson);
-
-            Assert.AreEqual(id, workstation?.Id);
-            Assert.AreEqual(name, workstation?.Name);
-
-            // new properties should have default enum values
-            Assert.AreEqual(default(WorkstationGroup), workstation.Group);
-            Assert.AreEqual(default(WorkstationType), workstation.Type);
-        }
-
     }
 }


### PR DESCRIPTION
avoid hardcoded materials
retrieve actual materialcodes for test before calling statistic