### PR TITLE
Add GetOrdersChangedSince to IOrderManagerClient

### DIFF
--- a/Applications/OrderManager/Client/OrderManagerClient.cs
+++ b/Applications/OrderManager/Client/OrderManagerClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -44,6 +45,14 @@ namespace HomagConnect.OrderManager.Client
         public async Task<IEnumerable<OrderOverview>?> GetOrders(int take, int skip = 0)
         {
             var url = $"{_OrderRoute}?take={take}&skip={skip}";
+            return await RequestEnumerable<OrderOverview>(new Uri(url, UriKind.Relative));
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<OrderOverview>?> GetOrdersChangedSince(OrderState orderState, DateTime changedSince, int take, int skip = 0)
+        {
+            var url =
+                $"{_OrderRoute}?&orderStatus={Uri.EscapeDataString(orderState.ToString())}&changedSince={Uri.EscapeDataString(changedSince.ToString(CultureInfo.InvariantCulture))}&take={take}&skip={skip}";
             return await RequestEnumerable<OrderOverview>(new Uri(url, UriKind.Relative));
         }
 

--- a/Applications/OrderManager/Contracts/IOrderManagerClient.cs
+++ b/Applications/OrderManager/Contracts/IOrderManagerClient.cs
@@ -31,6 +31,12 @@ namespace HomagConnect.OrderManager.Contracts
         /// </summary>
         Task<IEnumerable<OrderOverview>> GetOrders(string[] orderNumbers);
 
+        /// <summary>
+        /// Gets all orders for the given order state and the latest changedSince Date.
+        /// </summary>
+        /// >
+        Task<IEnumerable<OrderOverview>?> GetOrdersChangedSince(OrderState orderState, DateTime changedSince, int take, int skip = 0);
+
         #endregion
 
         #region Order details

--- a/Applications/OrderManager/Samples/CSharp/Orders/Actions/GetOrderSamples.cs
+++ b/Applications/OrderManager/Samples/CSharp/Orders/Actions/GetOrderSamples.cs
@@ -52,6 +52,14 @@ namespace HomagConnect.OrderManager.Samples.Orders.Actions
         }
 
         /// <summary />
+        public static async Task GetAllOrdersHavingStatusReadyForProductionAndLatestChangedSinceDate5MinsAgo(IOrderManagerClient orderManager)
+        {
+            var response = await orderManager.GetOrdersChangedSince(OrderState.ReadyForProduction, DateTime.UtcNow.AddMinutes(-5), 5);
+
+            response.Trace();
+        }
+
+        /// <summary />
         public static OrderDetails GetSampleOrder()
         {
             var order = new OrderDetails();


### PR DESCRIPTION
Implemented GetOrdersChangedSince in IOrderManagerClient and OrderManagerClient for filtered, paginated order retrieval by state and changedSince. Updated GetOrderSamples.cs with a usage example fetching ReadyForProduction orders changed in the last 5 minutes.