### PR TITLE
Fixed and enabled intelliDivide tests

### DIFF
--- a/Applications/IntelliDivide/Contracts/Result/SolutionOverviewFiguresMaterial.cs
+++ b/Applications/IntelliDivide/Contracts/Result/SolutionOverviewFiguresMaterial.cs
@@ -36,7 +36,7 @@ public class SolutionOverviewFiguresMaterial
     /// Gets the total number of offcuts.
     /// </summary>
     [JsonProperty(Order = 10)]
-    [Range(0, int.MaxValue)]
+    [Range(int.MinValue, int.MaxValue)]
     public int OffcutsTotal { get; set; }
 
     /// <summary>

--- a/Applications/IntelliDivide/Tests/Optimizations/OptimizationsCandidateEvaluationTests.cs
+++ b/Applications/IntelliDivide/Tests/Optimizations/OptimizationsCandidateEvaluationTests.cs
@@ -25,7 +25,6 @@ public class OptimizationsCandidateEvaluationTests : IntelliDivideTestBase
     private const double _MeterToFeet = 3.2808399;
 
     [TestMethod]
-    [TemporaryDisabledOnServer(2026, 05, 28, "DF-Optimization")]
     public async Task Optimizations_Cutting_GetFirstOptimizationAndEvaluate()
     {
         var solutions = await GetSampleSolutionDetails(OptimizationType.Cutting);
@@ -56,7 +55,6 @@ public class OptimizationsCandidateEvaluationTests : IntelliDivideTestBase
     }
 
     [TestMethod]
-    [TemporaryDisabledOnServer(2026, 10, 06, "DF-Optimization")] // Failing: OffcutsTotal validation error on solution candidate, see build 476495
     public async Task Optimizations_Nesting_GetFirstOptimizationAndEvaluate()
     {
         var solutions = await GetSampleSolutionDetails(OptimizationType.Nesting);


### PR DESCRIPTION
Fixed incorrect range for total offcuts. It can be negative if more offcuts are used in an optimization than are created by that optimization.
Enabled intelliDivide tests.